### PR TITLE
feat: redesign site with new navigation and dark theme

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,10 @@
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">About</h1>
+        <p className="mt-4 text-muted">Coming soon...</p>
+      </div>
+    </main>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,24 @@
-export default function BlogPage() {
-  return (
-    <div className="text-white">
-      <h1 className="text-3xl font-bold text-emerald-400 mb-4">Blog</h1>
-      <p>Coming soon...</p>
-    </div>
-  );
-}
+import Link from 'next/link'
 
+export default function BlogPage() {
+  const posts = [
+    { slug: 'databricks-pipeline-slos', title: 'SLOs for Data Pipelines', excerpt: 'Designing reliability you can measure.' },
+    { slug: 'aws-step-functions-observability', title: 'Observability for Step Functions', excerpt: 'Metrics that matter.' },
+  ]
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">Blog</h1>
+        <div className="mt-8 grid gap-6 sm:grid-cols-2">
+          {posts.map(p => (
+            <Link key={p.slug} href={`/blog/${p.slug}`} className="rounded-xl2 border border-stroke/70 bg-surface p-6 hover:border-mint/60">
+              <h3 className="font-heading text-text">{p.title}</h3>
+              <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
+              <span className="mt-3 block text-sm text-mint">Read →</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,10 @@
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">Contact</h1>
+        <p className="mt-4 text-muted">Reach us at <a href="mailto:hello@example.com" className="text-mint">hello@example.com</a></p>
+      </div>
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,19 +1,32 @@
 @import "tailwindcss";
 
 :root {
-  --background: #0f0f0f;
-  --foreground: #f8fafc;
-  --accent: #3ecf8e;
+  --bg: #0B0E11;
+  --surface: #111418;
+  --muted: #9CA3AF;
+  --text: #F3F4F6;
+  --mint: #36E2B4;
+  --mint-strong: #16C7A2;
+  --stroke: #1F2937;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-accent: var(--accent);
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-muted: var(--muted);
+  --color-text: var(--text);
+  --color-mint: var(--mint);
+  --color-mint-strong: var(--mint-strong);
+  --color-stroke: var(--stroke);
+  --shadow-soft: 0 6px 24px rgba(0,0,0,0.25);
+  --shadow-glow: 0 0 0 6px rgba(54,226,180,0.12);
+  --radius-xl2: 1rem;
+  --font-sans: var(--font-inter), sans-serif;
+  --font-heading: var(--font-sora), sans-serif;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,40 +1,27 @@
-import type { Metadata } from "next";
-import Link from "next/link";
-import "./globals.css";
+import type { Metadata } from 'next'
+import { Inter, Sora } from 'next/font/google'
+import './globals.css'
+import Navbar from '@/components/Navbar'
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' })
+const sora = Sora({ subsets: ['latin'], variable: '--font-sora', display: 'swap' })
 
 export const metadata: Metadata = {
-  title: "Supabase Style Web App",
-  description: "Simple app with Supabase-inspired design",
-};
+  title: 'AnalytiX | Code Groove',
+  description: 'Where data meets flow.',
+}
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: {
+  children: React.ReactNode
+}) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        <header className="bg-[#0d0d0d] border-b border-emerald-500">
-          <nav className="max-w-5xl mx-auto flex items-center justify-between p-4 text-white">
-            <Link href="/" className="text-emerald-400 font-bold">
-              Web App
-            </Link>
-            <div className="space-x-4">
-              <Link href="/auth" className="hover:text-emerald-400">
-                Auth
-              </Link>
-              <Link href="/solutions" className="hover:text-emerald-400">
-                Solutions
-              </Link>
-              <Link href="/blog" className="hover:text-emerald-400">
-                Blog
-              </Link>
-            </div>
-          </nav>
-        </header>
-        <main className="max-w-5xl mx-auto p-4">{children}</main>
+      <body className={`${inter.variable} ${sora.variable} bg-bg text-text antialiased`}>
+        <Navbar />
+        {children}
       </body>
     </html>
-  );
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,11 @@
+import Hero from '@/components/Hero'
+import ServiceCards from '@/components/ServiceCards'
+
 export default function Home() {
   return (
-    <section className="text-center text-white mt-20">
-      <h1 className="text-4xl font-bold mb-4 text-emerald-400">
-        Supabase Style App
-      </h1>
-      <p className="text-lg">
-        A minimal Next.js starter with Auth, Solutions, and Blog pages.
-      </p>
-    </section>
-  );
+    <main>
+      <Hero />
+      <ServiceCards />
+    </main>
+  )
 }
-

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,12 @@
+import ServiceCards from '@/components/ServiceCards'
+
+export default function ServicesPage() {
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">Services</h1>
+      </div>
+      <ServiceCards />
+    </main>
+  )
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+
+export default function Hero() {
+  return (
+    <section className="relative isolate overflow-hidden bg-bg">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+        style={{
+          background:
+            'radial-gradient(60% 60% at 70% 20%, rgba(54,226,180,0.09) 0%, rgba(0,0,0,0) 60%), linear-gradient(180deg, rgba(17,20,24,1) 0%, rgba(11,14,17,1) 100%)',
+          maskImage:
+            'radial-gradient(1200px 600px at 50% -10%, black 40%, transparent 70%)',
+        }}
+      />
+      <div className="absolute inset-0 -z-10 opacity-20 [background:repeating-linear-gradient(45deg,transparent,transparent_28px,_rgba(255,255,255,0.03)_30px,_rgba(255,255,255,0.03)_32px)]" />
+      <div className="mx-auto max-w-5xl px-4 py-24 text-center">
+        <h1 className="font-heading text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+          Where Data <span className="text-mint">Meets</span> Flow
+        </h1>
+        <p className="mx-auto mt-5 max-w-2xl text-base text-muted">
+          We build reliable data platforms and production-grade apps—fast,
+          observable, secure. Less friction, more groove.
+        </p>
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link
+            href="/services"
+            className="rounded-xl2 bg-mint px-5 py-2.5 text-sm font-medium text-black shadow-glow hover:opacity-90"
+          >
+            See services
+          </Link>
+          <Link
+            href="/blog"
+            className="rounded-xl2 border border-stroke/80 px-5 py-2.5 text-sm text-text/90 hover:border-mint hover:text-text"
+          >
+            Read the blog
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,45 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const links = [
+  { href: '/services', label: 'Services' },
+  { href: '/blog',     label: 'Blog' },
+  { href: '/about',    label: 'About' },
+  { href: '/contact',  label: 'Contact' },
+]
+
+export default function Navbar() {
+  const pathname = usePathname()
+  return (
+    <header className="sticky top-0 z-50 border-b border-stroke/60 bg-surface/70 backdrop-blur">
+      <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+        <Link href="/" aria-label="AnalytiX Code Groove" className="flex items-center gap-2">
+          <span className="text-text font-semibold tracking-wide">analyti<span className="text-mint">x</span></span>
+        </Link>
+        <div className="hidden gap-6 md:flex">
+          {links.map(l => {
+            const active = pathname.startsWith(l.href)
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                className={`text-sm transition-colors ${
+                  active ? 'text-mint' : 'text-text/80 hover:text-text'
+                }`}
+              >
+                {l.label}
+              </Link>
+            )
+          })}
+        </div>
+        <Link
+          href="/contact"
+          className="ml-4 hidden rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90 md:inline-block"
+        >
+          Let’s talk
+        </Link>
+      </nav>
+    </header>
+  )
+}

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -1,0 +1,30 @@
+type Card = { title: string; blurb: string; href: string }
+const cards: Card[] = [
+  { title: 'Data Engineering', blurb: 'Pipelines, orchestration, quality, SLOs.', href: '/services/data' },
+  { title: 'Cloud & DevOps', blurb: 'AWS, IaC, CI/CD, cost-safe scaling.', href: '/services/devops' },
+  { title: 'Analytics', blurb: 'Dashboards that drive decisions.', href: '/services/analytics' },
+  { title: 'AI / Automation', blurb: 'LLMs, agents, workflow automation.', href: '/services/ai' },
+  { title: 'Apps & APIs', blurb: 'From prototype to production.', href: '/services/apps' },
+]
+
+import Link from 'next/link'
+
+export default function ServiceCards() {
+  return (
+    <section className="bg-bg py-14">
+      <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map(c => (
+          <Link
+            key={c.href}
+            href={c.href}
+            className="group rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft transition hover:border-mint/60"
+          >
+            <h3 className="font-heading text-lg font-semibold text-text group-hover:text-mint">{c.title}</h3>
+            <p className="mt-2 text-sm text-muted">{c.blurb}</p>
+            <span className="mt-4 inline-block text-sm text-mint">Learn more →</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from 'tailwindcss'
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: 'var(--bg)',
+        surface: 'var(--surface)',
+        text: 'var(--text)',
+        muted: 'var(--muted)',
+        mint: 'var(--mint)',
+        'mint-strong': 'var(--mint-strong)',
+        stroke: 'var(--stroke)',
+      },
+      boxShadow: {
+        soft: '0 6px 24px rgba(0,0,0,0.25)',
+        glow: '0 0 0 6px rgba(54,226,180,0.12)',
+      },
+      borderRadius: {
+        xl2: '1rem',
+      },
+    },
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
## Summary
- set up Supabase-inspired dark theme tokens and Tailwind config
- add responsive navbar, hero, and service cards
- scaffold Services, Blog, About, and Contact pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b704b75588326b3a3956bafd941e6