### PR TITLE
Add offline bookmarks and Supabase auth

### DIFF
--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+type Bookmark = {
+  url: string
+}
+
+const merge = (local: Bookmark[], server: Bookmark[]): Bookmark[] => {
+  const map = new Map(local.map(b => [b.url, b]))
+  server.forEach(b => map.set(b.url, b))
+  return Array.from(map.values())
+}
+
+export default function BookmarksPage() {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
+  const [url, setUrl] = useState('')
+
+  const loadLocal = (): Bookmark[] => {
+    try {
+      return JSON.parse(localStorage.getItem('bookmarks') ?? '[]') as Bookmark[]
+    } catch {
+      return []
+    }
+  }
+
+  const saveLocal = (items: Bookmark[]) => {
+    localStorage.setItem('bookmarks', JSON.stringify(items))
+  }
+
+  useEffect(() => {
+    const sync = async () => {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (user) {
+        const { data } = await supabase
+          .from('bookmarks')
+          .select('url')
+          .eq('user_id', user.id)
+        if (data) {
+          const merged = merge(loadLocal(), data)
+          setBookmarks(merged)
+          saveLocal(merged)
+        }
+      }
+    }
+
+    const local = loadLocal()
+    setBookmarks(local)
+    sync()
+    const { subscription } = supabase.auth.onAuthStateChange(() => {
+      sync()
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const addBookmark = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!url) return
+    const newBookmarks = merge(bookmarks, [{ url }])
+    setBookmarks(newBookmarks)
+    saveLocal(newBookmarks)
+    setUrl('')
+    const { data: { user } } = await supabase.auth.getUser()
+    if (user) {
+      await supabase.from('bookmarks').upsert({ url, user_id: user.id })
+    }
+  }
+
+  return (
+    <main className="bg-bg min-h-screen p-4 text-text">
+      <h1 className="mb-4 text-2xl font-semibold">Bookmarks</h1>
+      <form onSubmit={addBookmark} className="mb-4 flex gap-2">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com"
+          className="flex-1 rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
+        />
+        <button
+          type="submit"
+          className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+        >
+          Add
+        </button>
+      </form>
+      {bookmarks.length === 0 ? (
+        <p className="text-sm text-text/80">No bookmarks yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {bookmarks.map(b => (
+            <li key={b.url}>
+              <a href={b.url} className="text-mint hover:underline">
+                {b.url}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,35 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { supabase } from '@/lib/supabase'
+
 export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+
+  const handleEmailLogin = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    setMessage(error ? error.message : 'Check your email for the login link.')
+  }
+
+  const handleProviderLogin = (provider: 'google' | 'github') => async () => {
+    const { error } = await supabase.auth.signInWithOAuth({ provider })
+    if (error) setMessage(error.message)
+  }
+
   return (
     <main className="bg-bg flex min-h-screen items-center justify-center px-4">
-      <form className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
+      <form onSubmit={handleEmailLogin} className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
         <h1 className="text-2xl font-semibold text-text">Log in</h1>
         <div className="mt-4 flex flex-col gap-4">
           <input
             type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
-            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
-          />
-          <input
-            type="password"
-            placeholder="Password"
             className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
           />
           <button
             type="submit"
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Log in
+            Send magic link
           </button>
+          <button
+            type="button"
+            onClick={handleProviderLogin('google')}
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            Sign in with Google
+          </button>
+          <button
+            type="button"
+            onClick={handleProviderLogin('github')}
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            Sign in with GitHub
+          </button>
+          {message && <p className="text-sm text-text">{message}</p>}
         </div>
         <div className="mt-4 flex justify-between text-sm">
-          <a href="/signup" className="text-mint hover:underline">
+          <Link href="/signup" className="text-mint hover:underline">
             Sign up
-          </a>
-          <a href="/forgot-password" className="text-mint hover:underline">
-            Forgot password?
-          </a>
+          </Link>
         </div>
       </form>
     </main>
   )
 }
+

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,38 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { supabase } from '@/lib/supabase'
+
 export default function SignupPage() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+
+  const handleEmailSignup = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithOtp({ email })
+    setMessage(error ? error.message : 'Check your email for the signup link.')
+  }
+
+  const handleProviderSignup = (provider: 'google' | 'github') => async () => {
+    const { error } = await supabase.auth.signInWithOAuth({ provider })
+    if (error) setMessage(error.message)
+  }
+
   return (
     <main className="bg-bg flex min-h-screen items-center justify-center px-4">
-      <form className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
+      <form onSubmit={handleEmailSignup} className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
         <h1 className="text-2xl font-semibold text-text">Sign up</h1>
         <div className="mt-4 flex flex-col gap-4">
           <input
-            type="text"
-            placeholder="Name"
-            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
-          />
-          <input
             type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             placeholder="Email"
-            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
-          />
-          <input
-            type="password"
-            placeholder="Password"
             className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
           />
           <button
             type="submit"
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Create account
+            Send magic link
           </button>
+          <button
+            type="button"
+            onClick={handleProviderSignup('google')}
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            Sign up with Google
+          </button>
+          <button
+            type="button"
+            onClick={handleProviderSignup('github')}
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            Sign up with GitHub
+          </button>
+          {message && <p className="text-sm text-text">{message}</p>}
         </div>
         <p className="mt-4 text-sm">
           Already have an account?{' '}
-          <a href="/login" className="text-mint hover:underline">
+          <Link href="/login" className="text-mint hover:underline">
             Log in
-          </a>
+          </Link>
         </p>
       </form>
     </main>
   )
 }
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 const links = [
   { href: '/services', label: 'Services' },
   { href: '/blog',     label: 'Blog' },
+  { href: '/bookmarks', label: 'Bookmarks' },
   { href: '/about',    label: 'About' },
   { href: '/contact',  label: 'Contact' },
 ]


### PR DESCRIPTION
## Summary
- add `/bookmarks` page that syncs local and server bookmarks
- integrate Supabase magic link and OAuth auth for login/signup
- link bookmarks in navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b7e51b6508326b1c1db7ec79befc5