### PR TITLE
feat: add services dropdown to navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,11 +3,18 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 const links = [
-  { href: '/services', label: 'Services' },
-  { href: '/blog',     label: 'Blog' },
+  {
+    href: '/services',
+    label: 'Services',
+    children: [
+      { href: '/services/data', label: 'Data Engineering' },
+      { href: '/services/devops', label: 'Cloud & DevOps' },
+    ],
+  },
+  { href: '/blog', label: 'Blog' },
   { href: '/bookmarks', label: 'Bookmarks' },
-  { href: '/about',    label: 'About' },
-  { href: '/contact',  label: 'Contact' },
+  { href: '/about', label: 'About' },
+  { href: '/contact', label: 'Contact' },
 ]
 
 export default function Navbar() {
@@ -21,11 +28,36 @@ export default function Navbar() {
         <div className="hidden gap-6 md:flex">
           {links.map(l => {
             const active = pathname.startsWith(l.href)
+            if (l.children) {
+              return (
+                <div key={l.href} className="relative group">
+                  <Link
+                    href={l.href}
+                    className={`text-sm font-bold transition-colors ${
+                      active ? 'text-mint' : 'text-text/80 hover:text-text'
+                    }`}
+                  >
+                    {l.label}
+                  </Link>
+                  <div className="absolute left-0 mt-2 hidden w-48 flex-col rounded-md border border-stroke/60 bg-surface shadow-soft group-hover:flex">
+                    {l.children.map(child => (
+                      <Link
+                        key={child.href}
+                        href={child.href}
+                        className="px-4 py-2 text-sm text-text/80 hover:bg-mint/10 hover:text-text"
+                      >
+                        {child.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )
+            }
             return (
               <Link
                 key={l.href}
                 href={l.href}
-                className={`text-sm transition-colors ${
+                className={`text-sm font-bold transition-colors ${
                   active ? 'text-mint' : 'text-text/80 hover:text-text'
                 }`}
               >


### PR DESCRIPTION
## Summary
- make navbar section labels bold
- add Services dropdown menu for Data Engineering and Cloud & DevOps links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b96ad5e4c8326aedc6839808b1b1a