### PR TITLE
feat: add services dropdown to navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,11 +3,18 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 const links = [
-  { href: '/services', label: 'Services' },
-  { href: '/blog',     label: 'Blog' },
+  {
+    href: '/services',
+    label: 'Services',
+    children: [
+      { href: '/services/data', label: 'Data Engineering' },
+      { href: '/services/devops', label: 'Cloud & DevOps' },
+    ],
+  },
+  { href: '/blog', label: 'Blog' },
   { href: '/bookmarks', label: 'Bookmarks' },
-  { href: '/about',    label: 'About' },
-  { href: '/contact',  label: 'Contact' },
+  { href: '/about', label: 'About' },
+  { href: '/contact', label: 'Contact' },
 ]
 
 export default function Navbar() {
@@ -18,14 +25,39 @@ export default function Navbar() {
         <Link href="/" aria-label="AnalytiX Code Groove" className="flex items-center gap-2">
           <span className="text-text font-semibold tracking-wide">analyti<span className="text-mint">x</span></span>
         </Link>
-        <div className="hidden gap-6 md:flex">
+        <div className="hidden items-center gap-6 md:flex">
           {links.map(l => {
             const active = pathname.startsWith(l.href)
+            if (l.children) {
+              return (
+                <div key={l.href} className="relative group flex items-center">
+                  <Link
+                    href={l.href}
+                    className={`text-sm font-bold transition-colors ${
+                      active ? 'text-mint' : 'text-text/80 hover:text-text'
+                    }`}
+                  >
+                    {l.label}
+                  </Link>
+                  <div className="absolute left-0 mt-2 hidden w-48 flex-col rounded-md border border-stroke/60 bg-surface shadow-soft group-hover:flex">
+                    {l.children.map(child => (
+                      <Link
+                        key={child.href}
+                        href={child.href}
+                        className="px-4 py-2 text-sm text-text/80 hover:bg-mint/10 hover:text-text"
+                      >
+                        {child.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )
+            }
             return (
               <Link
                 key={l.href}
                 href={l.href}
-                className={`text-sm transition-colors ${
+                className={`text-sm font-bold transition-colors ${
                   active ? 'text-mint' : 'text-text/80 hover:text-text'
                 }`}
               >
@@ -34,18 +66,20 @@ export default function Navbar() {
             )
           })}
         </div>
-        <Link
-          href="/login"
-          className="ml-4 hidden text-sm text-text/80 transition-colors hover:text-text md:inline-block"
-        >
-          Log in
-        </Link>
-        <Link
-          href="/contact"
-          className="ml-4 hidden rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90 md:inline-block"
-        >
-          Let’s talk
-        </Link>
+        <div className="hidden items-center gap-4 md:flex">
+          <Link
+            href="/login"
+            className="text-sm text-text/80 transition-colors hover:text-text"
+          >
+            Log in
+          </Link>
+          <Link
+            href="/contact"
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90"
+          >
+            Let’s talk
+          </Link>
+        </div>
       </nav>
     </header>
   )


### PR DESCRIPTION
## Summary
- make navbar section labels bold
- add Services dropdown menu for Data Engineering and Cloud & DevOps links
- align navbar options by centering links and grouping action buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b96ad5e4c8326aedc6839808b1b1a