### PR TITLE
Reorder navbar menu items

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 const links = [
+  { href: '/about', label: 'About' },
   {
     href: '/services',
     label: 'Services',
@@ -12,9 +13,6 @@ const links = [
     ],
   },
   { href: '/blog', label: 'Blog' },
-  { href: '/bookmarks', label: 'Bookmarks' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
 ]
 
 export default function Navbar() {


### PR DESCRIPTION
## Summary
- Reorder navbar links to `About`, `Services`, and `Blog`
- Remove `Bookmarks` and `Contact` links from navbar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9b34da0c83269ca097386e19ab1c