### PR TITLE
Add Spanish localization and language switching

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Sora } from 'next/font/google'
 import './globals.css'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
+import { LanguageProvider } from '@/lib/i18n'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' })
 const sora = Sora({ subsets: ['latin'], variable: '--font-sora', display: 'swap' })
@@ -20,9 +21,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} ${sora.variable} bg-bg text-text antialiased flex min-h-screen flex-col`}>
-        <Navbar />
-        <div className="flex-1">{children}</div>
-        <Footer />
+        <LanguageProvider>
+          <Navbar />
+          <div className="flex-1">{children}</div>
+          <Footer />
+        </LanguageProvider>
       </body>
     </html>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,25 +1,29 @@
 import Link from 'next/link'
+import { useLanguage } from '@/lib/i18n'
 
 const links = [
-  { href: '/services', label: 'Services' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-  { href: '/login', label: 'Log in' },
+  { href: '/services', label: 'services' },
+  { href: '/blog', label: 'blog' },
+  { href: '/about', label: 'about' },
+  { href: '/contact', label: 'contact' },
+  { href: '/login', label: 'login' },
 ]
 
 export default function Footer() {
+  const { t } = useLanguage()
   return (
     <footer className="border-t border-stroke/60 bg-surface/70 backdrop-blur">
       <div className="mx-auto max-w-7xl px-4 py-8 text-center text-sm text-muted">
         <nav className="mb-4 flex justify-center gap-6">
           {links.map(l => (
             <Link key={l.href} href={l.href} className="transition-colors hover:text-text">
-              {l.label}
+              {t(l.label)}
             </Link>
           ))}
         </nav>
-        <p>&copy; {new Date().getFullYear()} AnalytiX | Code Groove. All rights reserved.</p>
+        <p>
+          &copy; {new Date().getFullYear()} AnalytiX | Code Groove. {t('rights')}
+        </p>
       </div>
     </footer>
   )

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
+import { useLanguage } from '@/lib/i18n'
 
 export default function Hero() {
+  const { t } = useLanguage()
   return (
     <section className="relative isolate overflow-hidden bg-bg">
       <div
@@ -16,24 +18,23 @@ export default function Hero() {
       <div className="absolute inset-0 -z-10 opacity-20 [background:repeating-linear-gradient(45deg,transparent,transparent_28px,_rgba(255,255,255,0.03)_30px,_rgba(255,255,255,0.03)_32px)]" />
       <div className="mx-auto max-w-5xl px-4 py-24 text-center">
         <h1 className="font-heading text-4xl font-semibold tracking-tight text-text sm:text-6xl">
-          Where Data <span className="text-mint">Meets</span> Flow
+          {t('whereData')} <span className="text-mint">{t('meets')}</span> {t('flow')}
         </h1>
         <p className="mx-auto mt-5 max-w-2xl text-base text-muted">
-          We build reliable data platforms and production-grade apps—fast,
-          observable, secure. Less friction, more groove.
+          {t('heroParagraph')}
         </p>
         <div className="mt-8 flex items-center justify-center gap-3">
           <Link
             href="/services"
             className="rounded-xl2 bg-mint px-5 py-2.5 text-sm font-medium text-black shadow-glow hover:opacity-90"
           >
-            See services
+            {t('seeServices')}
           </Link>
           <Link
             href="/blog"
             className="rounded-xl2 border border-stroke/80 px-5 py-2.5 text-sm text-text/90 hover:border-mint hover:text-text"
           >
-            Read the blog
+            {t('readBlog')}
           </Link>
         </div>
       </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,17 +2,18 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useRef, useState } from 'react'
+import { useLanguage } from '@/lib/i18n'
 
 const links = [
-  { href: '/about', label: 'About' },
+  { href: '/about', label: 'about' },
   {
     href: '/solutions',
-    label: 'Solutions',
+    label: 'solutions',
     children: [
       {
         href: '/services/data',
-        label: 'Data Engineering',
-        description: 'ETL pipelines, warehouses & lakes',
+        label: 'dataEngineering',
+        description: 'dataEngineeringDesc',
         icon: (
           <svg
             viewBox="0 0 24 24"
@@ -29,8 +30,8 @@ const links = [
       },
       {
         href: '/services/devops',
-        label: 'Cloud & DevOps',
-        description: 'Infrastructure automation & reliability',
+        label: 'cloudDevops',
+        description: 'cloudDevopsDesc',
         icon: (
           <svg
             viewBox="0 0 24 24"
@@ -45,13 +46,14 @@ const links = [
       },
     ],
   },
-  { href: '/blog', label: 'Blog' },
+  { href: '/blog', label: 'blog' },
 ]
 
 export default function Navbar() {
   const pathname = usePathname()
   const [servicesOpen, setServicesOpen] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const { t, lang, setLang } = useLanguage()
 
   const openMenu = () => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current)
@@ -85,7 +87,7 @@ export default function Navbar() {
                       active ? 'text-mint' : 'text-text/80 hover:text-text'
                     }`}
                   >
-                    {l.label}
+                    {t(l.label)}
                   </Link>
                   <svg
                     viewBox="0 0 24 24"
@@ -116,11 +118,11 @@ export default function Navbar() {
                             </span>
                             <span className="text-left">
                               <span className="block text-sm font-semibold text-text">
-                                {child.label}
+                                {t(child.label)}
                               </span>
                               {child.description && (
                                 <span className="block text-xs text-text/70">
-                                  {child.description}
+                                  {t(child.description)}
                                 </span>
                               )}
                             </span>
@@ -140,23 +142,29 @@ export default function Navbar() {
                   active ? 'text-mint' : 'text-text/80 hover:text-text'
                 }`}
               >
-                {l.label}
+                {t(l.label)}
               </Link>
             )
           })}
         </div>
         <div className="hidden items-center gap-4 md:flex">
+          <button
+            onClick={() => setLang(lang === 'en' ? 'es' : 'en')}
+            className="text-sm text-text/80 transition-colors hover:text-text"
+          >
+            {lang === 'en' ? 'ES' : 'EN'}
+          </button>
           <Link
             href="/login"
             className="text-sm text-text/80 transition-colors hover:text-text"
           >
-            Log in
+            {t('login')}
           </Link>
           <Link
             href="/contact"
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90"
           >
-            Let’s talk
+            {t('letsTalk')}
           </Link>
         </div>
       </nav>

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -1,15 +1,17 @@
 type Card = { title: string; blurb: string; href: string }
 const cards: Card[] = [
-  { title: 'Data Engineering', blurb: 'Pipelines, orchestration, quality, SLOs.', href: '/services/data' },
-  { title: 'Cloud & DevOps', blurb: 'AWS, IaC, CI/CD, cost-safe scaling.', href: '/services/devops' },
-  { title: 'Analytics', blurb: 'Dashboards that drive decisions.', href: '/services/analytics' },
-  { title: 'AI / Automation', blurb: 'LLMs, agents, workflow automation.', href: '/services/ai' },
-  { title: 'Apps & APIs', blurb: 'From prototype to production.', href: '/services/apps' },
+  { title: 'dataEngineering', blurb: 'dataEngineeringCard', href: '/services/data' },
+  { title: 'cloudDevops', blurb: 'cloudDevopsCard', href: '/services/devops' },
+  { title: 'analytics', blurb: 'analyticsCard', href: '/services/analytics' },
+  { title: 'aiAutomation', blurb: 'aiAutomationCard', href: '/services/ai' },
+  { title: 'appsApis', blurb: 'appsApisCard', href: '/services/apps' },
 ]
 
 import Link from 'next/link'
+import { useLanguage } from '@/lib/i18n'
 
 export default function ServiceCards() {
+  const { t } = useLanguage()
   return (
     <section className="bg-bg py-14">
       <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -19,9 +21,9 @@ export default function ServiceCards() {
             href={c.href}
             className="group rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft transition hover:border-mint/60"
           >
-            <h3 className="font-heading text-lg font-semibold text-text group-hover:text-mint">{c.title}</h3>
-            <p className="mt-2 text-sm text-muted">{c.blurb}</p>
-            <span className="mt-4 inline-block text-sm text-mint">Learn more →</span>
+            <h3 className="font-heading text-lg font-semibold text-text group-hover:text-mint">{t(c.title)}</h3>
+            <p className="mt-2 text-sm text-muted">{t(c.blurb)}</p>
+            <span className="mt-4 inline-block text-sm text-mint">{t('learnMore')}</span>
           </Link>
         ))}
       </div>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Language = 'en' | 'es'
+
+const translations: Record<Language, Record<string, string>> = {
+  en: {
+    about: 'About',
+    solutions: 'Solutions',
+    dataEngineering: 'Data Engineering',
+    dataEngineeringDesc: 'ETL pipelines, warehouses & lakes',
+    dataEngineeringCard: 'Pipelines, orchestration, quality, SLOs.',
+    cloudDevops: 'Cloud & DevOps',
+    cloudDevopsDesc: 'Infrastructure automation & reliability',
+    cloudDevopsCard: 'AWS, IaC, CI/CD, cost-safe scaling.',
+    blog: 'Blog',
+    services: 'Services',
+    contact: 'Contact',
+    login: 'Log in',
+    letsTalk: "Let’s talk",
+    seeServices: 'See services',
+    readBlog: 'Read the blog',
+    whereData: 'Where Data',
+    meets: 'Meets',
+    flow: 'Flow',
+    heroParagraph:
+      'We build reliable data platforms and production-grade apps—fast, observable, secure. Less friction, more groove.',
+    analytics: 'Analytics',
+    analyticsCard: 'Dashboards that drive decisions.',
+    aiAutomation: 'AI / Automation',
+    aiAutomationCard: 'LLMs, agents, workflow automation.',
+    appsApis: 'Apps & APIs',
+    appsApisCard: 'From prototype to production.',
+    learnMore: 'Learn more →',
+    rights: 'All rights reserved.',
+  },
+  es: {
+    about: 'Acerca de',
+    solutions: 'Soluciones',
+    dataEngineering: 'Ingeniería de Datos',
+    dataEngineeringDesc: 'Pipelines ETL, almacenes y lagos',
+    dataEngineeringCard: 'Pipelines, orquestación, calidad, SLOs.',
+    cloudDevops: 'Nube y DevOps',
+    cloudDevopsDesc: 'Automatización de infraestructura y fiabilidad',
+    cloudDevopsCard: 'AWS, IaC, CI/CD, escalado rentable.',
+    blog: 'Blog',
+    services: 'Servicios',
+    contact: 'Contacto',
+    login: 'Iniciar sesión',
+    letsTalk: 'Hablemos',
+    seeServices: 'Ver servicios',
+    readBlog: 'Leer el blog',
+    whereData: 'Donde los datos',
+    meets: 'se encuentran con el',
+    flow: 'flujo',
+    heroParagraph:
+      'Construimos plataformas de datos confiables y aplicaciones de producción: rápidas, observables y seguras. Menos fricción, más ritmo.',
+    analytics: 'Analítica',
+    analyticsCard: 'Paneles que impulsan decisiones.',
+    aiAutomation: 'IA / Automatización',
+    aiAutomationCard: 'LLMs, agentes, automatización de flujos.',
+    appsApis: 'Apps y APIs',
+    appsApisCard: 'Del prototipo a la producción.',
+    learnMore: 'Aprender más →',
+    rights: 'Todos los derechos reservados.',
+  },
+}
+
+interface LanguageContextProps {
+  lang: Language
+  setLang: (lang: Language) => void
+  t: (key: string) => string
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(
+  undefined
+)
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLangState] = useState<Language>('en')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lang') as Language | null
+    if (stored) {
+      setLangState(stored)
+    } else {
+      const browser = navigator.language.slice(0, 2)
+      if (browser === 'es') setLangState('es')
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.lang = lang
+  }, [lang])
+
+  const setLang = (l: Language) => {
+    setLangState(l)
+    localStorage.setItem('lang', l)
+  }
+
+  const t = (key: string) => translations[lang][key] ?? key
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+  if (!context) throw new Error('useLanguage must be used within LanguageProvider')
+  return context
+}
+


### PR DESCRIPTION
## Summary
- add language context with English and Spanish translations
- detect user language, store choice, and update document `lang`
- translate navbar, footer, hero and service cards and add language toggle

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bac9257548326b662e20465a0d2fc