### PR TITLE
fix: mark footer as client component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import { useLanguage } from '@/lib/i18n'
 


### PR DESCRIPTION
## Summary
- mark Footer component as client to allow useLanguage hook

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` and `Sora` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689bb388357083269e47b3437fa61335