### PR TITLE
Self-host fonts via fontsource and defer Supabase client creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "web-app",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.6",
+        "@fontsource-variable/sora": "^5.2.6",
         "@supabase/supabase-js": "^2.55.0",
         "next": "15.4.6",
         "react": "19.1.0",
@@ -224,6 +226,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/sora": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.2.6.tgz",
+      "integrity": "sha512-9cVxKZXAdZIsPfCV+/dIn5zbvmAhXiqNXZdh2454n7Dk7U7nQ9ZfQuh2Q/De/qgzSUwQldTLlHMzgJ3OtOt67w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.6",
+    "@fontsource-variable/sora": "^5.2.6",
     "@supabase/supabase-js": "^2.55.0",
     "next": "15.4.6",
     "react": "19.1.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import '@fontsource-variable/inter';
+@import '@fontsource-variable/sora';
 
 :root {
   --bg: #0B0E11;
@@ -21,8 +23,8 @@
   --shadow-soft: 0 6px 24px rgba(0,0,0,0.25);
   --shadow-glow: 0 0 0 6px rgba(54,226,180,0.12);
   --radius-xl2: 1rem;
-  --font-sans: var(--font-inter), sans-serif;
-  --font-heading: var(--font-sora), sans-serif;
+  --font-sans: "Inter Variable", sans-serif;
+  --font-heading: "Sora Variable", sans-serif;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,8 @@
 import type { Metadata } from 'next'
-import { Inter, Sora } from 'next/font/google'
 import './globals.css'
 import Navbar from '@/components/Navbar'
 import Footer from '@/components/Footer'
 import { LanguageProvider } from '@/lib/i18n'
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' })
-const sora = Sora({ subsets: ['latin'], variable: '--font-sora', display: 'swap' })
 
 export const metadata: Metadata = {
   title: 'AnalytiX | Code Groove',
@@ -20,7 +16,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${sora.variable} bg-bg text-text antialiased flex min-h-screen flex-col`}>
+      <body className="bg-bg text-text antialiased flex min-h-screen flex-col">
         <LanguageProvider>
           <Navbar />
           <div className="flex-1">{children}</div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { supabase } from '../../lib/supabase'
+import { createSupabaseBrowserClient } from '../../lib/supabase'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -10,11 +10,13 @@ export default function LoginPage() {
 
   const handleEmailLogin = async (e: React.FormEvent) => {
     e.preventDefault()
+    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOtp({ email })
     setMessage(error ? error.message : 'Check your email for the login link.')
   }
 
   const handleProviderLogin = (provider: 'google' | 'github') => async () => {
+    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOAuth({ provider })
     if (error) setMessage(error.message)
   }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { supabase } from '../../lib/supabase'
+
+import { createSupabaseBrowserClient } from '../../lib/supabase'
 
 export default function SignupPage() {
   const [email, setEmail] = useState('')
@@ -10,11 +11,13 @@ export default function SignupPage() {
 
   const handleEmailSignup = async (e: React.FormEvent) => {
     e.preventDefault()
+    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOtp({ email })
     setMessage(error ? error.message : 'Check your email for the signup link.')
   }
 
   const handleProviderSignup = (provider: 'google' | 'github') => async () => {
+    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOAuth({ provider })
     if (error) setMessage(error.message)
   }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from 'next/link'
 import { useLanguage } from '@/lib/i18n'
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Link from 'next/link'
 import { useLanguage } from '@/lib/i18n'
 

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 type Card = { title: string; blurb: string; href: string }
 const cards: Card[] = [
   { title: 'dataEngineering', blurb: 'dataEngineeringCard', href: '/services/data' },

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,10 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export function createSupabaseBrowserClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Missing Supabase environment variables')
+  }
+  return createClient(supabaseUrl, supabaseAnonKey)
+}


### PR DESCRIPTION
## Summary
- bundle Inter and Sora fonts using `@fontsource-variable` packages, removing binary font files and updating global styling
- mark UI components that use `useLanguage` as client components
- create Supabase browser client on demand to avoid build-time env variable errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb2e2bbd08326a3a950d031a18057