### PR TITLE
refactor: isolate login view

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
-import Navbar from '@/components/Navbar'
-import Footer from '@/components/Footer'
-import { LanguageProvider } from '@/lib/i18n'
+import ClientLayout from '@/components/ClientLayout'
 
 export const metadata: Metadata = {
   title: 'AnalytiX | Code Groove',
@@ -17,11 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-bg text-text antialiased flex min-h-screen flex-col">
-        <LanguageProvider>
-          <Navbar />
-          <div className="flex-1">{children}</div>
-          <Footer />
-        </LanguageProvider>
+        <ClientLayout>{children}</ClientLayout>
       </body>
     </html>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,13 +3,17 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { FaGithub, FaGoogle } from 'react-icons/fa'
+import { FaGithub, FaGoogle, FaTimes } from 'react-icons/fa'
+import { useRouter } from 'next/navigation'
+import { useLanguage } from '@/lib/i18n'
 import { createSupabaseBrowserClient } from '../../lib/supabase'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState('')
+  const router = useRouter()
+  const { t } = useLanguage()
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -38,11 +42,20 @@ export default function LoginPage() {
         />
       </div>
 
+      {/* Close */}
+      <button
+        onClick={() => router.back()}
+        className="absolute right-6 top-6 text-text hover:opacity-70"
+        aria-label="Close"
+      >
+        <FaTimes className="h-6 w-6" />
+      </button>
+
       {/* Card */}
       <div className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 text-center shadow-soft">
         {/* Heading to match screenshot */}
-        <h1 className="text-3xl font-semibold tracking-tight text-text">Welcome back</h1>
-        <p className="mt-2 mb-10 text-sm text-muted">Sign in to your account</p>
+        <h1 className="text-3xl font-semibold tracking-tight text-text">{t('welcomeBack')}</h1>
+        <p className="mt-2 mb-10 text-sm text-muted">{t('signInToAccount')}</p>
 
         {/* Social buttons */}
         <div className="mb-6 flex flex-col gap-3">
@@ -52,7 +65,7 @@ export default function LoginPage() {
             className="flex items-center justify-center gap-2 rounded-xl2 border border-stroke/60 bg-bg px-4 py-2 text-sm font-medium text-text transition hover:bg-bg/80"
           >
             <FaGithub className="h-5 w-5" />
-            <span>Continue with GitHub</span>
+            <span>{t('continueWithGithub')}</span>
           </button>
           <button
             type="button"
@@ -60,35 +73,35 @@ export default function LoginPage() {
             className="flex items-center justify-center gap-2 rounded-xl2 border border-stroke/60 bg-bg px-4 py-2 text-sm font-medium text-text transition hover:bg-bg/80"
           >
             <FaGoogle className="h-5 w-5" />
-            <span>Continue with Google</span>
+            <span>{t('continueWithGoogle')}</span>
           </button>
         </div>
 
         {/* Divider */}
         <div className="mb-6 flex items-center">
           <span className="h-px flex-1 bg-stroke/40" />
-          <span className="px-2 text-sm tracking-wide text-muted">or</span>
+          <span className="px-2 text-sm tracking-wide text-muted">{t('or')}</span>
           <span className="h-px flex-1 bg-stroke/40" />
         </div>
 
         {/* Form */}
         <form onSubmit={handleLogin} className="flex flex-col gap-3 text-left">
-          <label htmlFor="email" className="text-xs text-muted">Email</label>
+          <label htmlFor="email" className="text-xs text-muted">{t('email')}</label>
           <input
             id="email"
             type="email"
             autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
+            placeholder={t('emailPlaceholder')}
             className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
             required
           />
 
           <div className="mt-2 flex items-end justify-between">
-            <label htmlFor="password" className="text-xs text-muted">Password</label>
+            <label htmlFor="password" className="text-xs text-muted">{t('password')}</label>
             <Link href="/forgot-password" className="text-xs font-medium text-mint hover:opacity-90">
-              Forgot Password?
+              {t('forgotPassword')}
             </Link>
           </div>
           <input
@@ -97,7 +110,7 @@ export default function LoginPage() {
             autoComplete="current-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            placeholder="••••••••••"
+            placeholder={t('passwordPlaceholder')}
             className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
             required
           />
@@ -106,20 +119,19 @@ export default function LoginPage() {
             type="submit"
             className="mt-4 rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Sign In
+            {t('signIn')}
           </button>
         </form>
 
         {message && <p className="mt-4 text-sm text-text" role="alert">{message}</p>}
 
         <p className="mt-8 text-sm text-muted">
-          Don&apos;t have an account?{' '}
-          <Link href="/signup" className="font-medium text-mint hover:opacity-90">Sign Up Now</Link>
+          {t('dontHaveAccount')}{' '}
+          <Link href="/signup" className="font-medium text-mint hover:opacity-90">{t('signUpNow')}</Link>
         </p>
 
         <p className="mt-16 text-xs leading-relaxed text-muted">
-          By continuing, you agree to Analytix&apos;s Terms of Service and Privacy Policy,
-          and to receive periodic emails with updates.
+          {t('termsAgreement')}
         </p>
       </div>
     </main>

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { useEffect } from 'react'
+import Navbar from './Navbar'
+import Footer from './Footer'
+import { LanguageProvider } from '@/lib/i18n'
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const showChrome = pathname !== '/login'
+
+  useEffect(() => {
+    if (pathname === '/login') {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+  }, [pathname])
+
+  return (
+    <LanguageProvider>
+      {showChrome && <Navbar />}
+      <div className="flex-1">{children}</div>
+      {showChrome && <Footer />}
+    </LanguageProvider>
+  )
+}
+

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -34,6 +34,21 @@ const translations: Record<Language, Record<string, string>> = {
     appsApisCard: 'From prototype to production.',
     learnMore: 'Learn more →',
     rights: 'All rights reserved.',
+    welcomeBack: 'Welcome back',
+    signInToAccount: 'Sign in to your account',
+    continueWithGithub: 'Continue with GitHub',
+    continueWithGoogle: 'Continue with Google',
+    or: 'or',
+    email: 'Email',
+    emailPlaceholder: 'you@example.com',
+    password: 'Password',
+    passwordPlaceholder: '••••••••••',
+    forgotPassword: 'Forgot Password?',
+    signIn: 'Sign In',
+    dontHaveAccount: "Don't have an account?",
+    signUpNow: 'Sign Up Now',
+    termsAgreement:
+      "By continuing, you agree to Analytix's Terms of Service and Privacy Policy, and to receive periodic emails with updates.",
   },
   es: {
     about: 'Acerca de',
@@ -64,6 +79,21 @@ const translations: Record<Language, Record<string, string>> = {
     appsApisCard: 'Del prototipo a la producción.',
     learnMore: 'Aprender más →',
     rights: 'Todos los derechos reservados.',
+    welcomeBack: 'Bienvenido de nuevo',
+    signInToAccount: 'Inicia sesión en tu cuenta',
+    continueWithGithub: 'Continuar con GitHub',
+    continueWithGoogle: 'Continuar con Google',
+    or: 'o',
+    email: 'Correo electrónico',
+    emailPlaceholder: 'tu@ejemplo.com',
+    password: 'Contraseña',
+    passwordPlaceholder: '••••••••••',
+    forgotPassword: '¿Olvidaste tu contraseña?',
+    signIn: 'Iniciar sesión',
+    dontHaveAccount: '¿No tienes una cuenta?',
+    signUpNow: 'Regístrate ahora',
+    termsAgreement:
+      'Al continuar, aceptas los Términos de Servicio y la Política de Privacidad de Analytix y recibir correos electrónicos periódicos con actualizaciones.',
   },
 }
 
@@ -78,17 +108,15 @@ const LanguageContext = createContext<LanguageContextProps | undefined>(
 )
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [lang, setLangState] = useState<Language>('en')
-
-  useEffect(() => {
-    const stored = localStorage.getItem('lang') as Language | null
-    if (stored) {
-      setLangState(stored)
-    } else {
+  const [lang, setLangState] = useState<Language>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('lang') as Language | null
+      if (stored) return stored
       const browser = navigator.language.slice(0, 2)
-      if (browser === 'es') setLangState('es')
+      if (browser === 'es') return 'es'
     }
-  }, [])
+    return 'en'
+  })
 
   useEffect(() => {
     document.documentElement.lang = lang

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,6 +8,7 @@ export function createSupabaseBrowserClient(): SupabaseClient {
   if ((!supabaseUrl || !supabaseAnonKey) && process.env.NODE_ENV === 'development') {
     try {
       // This file should be in your project root or /src/config, and .gitignore'd
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const localConfig = require('./supabase.local.json')
       supabaseUrl = localConfig.SUPABASE_URL
       supabaseAnonKey = localConfig.SUPABASE_ANON_KEY


### PR DESCRIPTION
## Summary
- add client-side layout to hide navbar/footer on login and lock scrolling
- localize login page with preloaded language and close button
- silence require lint for Supabase fallback config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8ef5b9b08326acfe3438476f06a9