### PR TITLE
Increase homepage logo size

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -68,7 +68,7 @@ export default function Navbar() {
     <header className="sticky top-0 z-50 border-b border-stroke/60 bg-surface/70 backdrop-blur">
       <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
         <Link href="/" aria-label="AnalytiX Code Groove" className="flex items-center gap-2">
-          <span className="text-text font-semibold tracking-wide">analyti<span className="text-mint">x</span></span>
+          <span className="text-text font-semibold tracking-wide text-[1.3rem]">analyti<span className="text-mint">x</span></span>
         </Link>
         <div className="hidden items-center gap-6 md:flex">
           {links.map(l => {


### PR DESCRIPTION
## Summary
- enlarge site logo by 30% using Tailwind's `text-[1.3rem]`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dedc94ec48326a451d2628fa28bf1