### PR TITLE
Rename Solutions to Services

### DIFF
--- a/src/app/solutions/page.tsx
+++ b/src/app/solutions/page.tsx
@@ -1,9 +1,0 @@
-export default function SolutionsPage() {
-  return (
-    <div className="text-white">
-      <h1 className="text-3xl font-bold text-emerald-400 mb-4">Solutions</h1>
-      <p>We build modern apps with a Supabase-inspired aesthetic.</p>
-    </div>
-  );
-}
-

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,8 +7,8 @@ import { useLanguage } from '@/lib/i18n'
 const links = [
   { href: '/about', label: 'about' },
   {
-    href: '/solutions',
-    label: 'solutions',
+    href: '/services',
+    label: 'services',
     children: [
       {
         href: '/services/data',

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -7,7 +7,6 @@ type Language = 'en' | 'es'
 const translations: Record<Language, Record<string, string>> = {
   en: {
     about: 'About',
-    solutions: 'Solutions',
     dataEngineering: 'Data Engineering',
     dataEngineeringDesc: 'ETL pipelines, warehouses & lakes',
     dataEngineeringCard: 'Pipelines, orchestration, quality, SLOs.',
@@ -52,7 +51,6 @@ const translations: Record<Language, Record<string, string>> = {
   },
   es: {
     about: 'Acerca de',
-    solutions: 'Soluciones',
     dataEngineering: 'Ingeniería de Datos',
     dataEngineeringDesc: 'Pipelines ETL, almacenes y lagos',
     dataEngineeringCard: 'Pipelines, orquestación, calidad, SLOs.',


### PR DESCRIPTION
## Summary
- Replace navigation item "Solutions" with "Services"
- Drop obsolete Solutions route and update translations accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689df2643f188326a72dfe80619005d5