### PR TITLE
Replace homepage logo with device-specific images

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,8 +1,11 @@
 'use client'
 import Link from 'next/link'
+import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { useLanguage } from '@/lib/i18n'
+import logoDesktop from '@/images/logos/desktop/logo_navbar.png'
+import logoMobile from '@/images/logos/mobile/logo_navbar.png'
 
 const links = [
   { href: '/about', label: 'about' },
@@ -67,8 +70,19 @@ export default function Navbar() {
   return (
     <header className="sticky top-0 z-50 border-b border-stroke/60 bg-surface/70 backdrop-blur">
       <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-        <Link href="/" aria-label="AnalytiX Code Groove" className="flex items-center gap-2">
-          <span className="text-text font-semibold tracking-wide text-[1.5rem]">analyti<span className="text-mint">x</span></span>
+        <Link href="/" aria-label="AnalytiX Code Groove" className="flex items-center">
+          <Image
+            src={logoMobile}
+            alt="AnalytiX Code Groove"
+            className="h-8 w-auto md:hidden"
+            priority
+          />
+          <Image
+            src={logoDesktop}
+            alt="AnalytiX Code Groove"
+            className="hidden h-8 w-auto md:block"
+            priority
+          />
         </Link>
         <div className="hidden items-center gap-6 md:flex">
           {links.map(l => {


### PR DESCRIPTION
## Summary
- use new desktop and mobile logo assets in navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Can't resolve '../../../supabase.local.json')*

------
https://chatgpt.com/codex/tasks/task_e_689df41ed3248326b8bcf7b3478fdc8b