### PR TITLE
feat: add separator line in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,13 +16,14 @@ export default function Footer() {
   return (
     <footer className="border-t border-stroke/60 bg-surface/70 backdrop-blur">
       <div className="mx-auto max-w-7xl px-4 py-8 text-center text-sm text-muted">
-        <nav className="mb-4 flex justify-center gap-6">
+        <nav className="flex justify-center gap-6">
           {links.map(l => (
             <Link key={l.href} href={l.href} className="transition-colors hover:text-text">
               {t(l.label)}
             </Link>
           ))}
         </nav>
+        <div className="my-4 h-px w-full bg-stroke/60" />
         <p>
           &copy; {new Date().getFullYear()} AnalytiX | Code Groove. {t('rights')}
         </p>


### PR DESCRIPTION
## Summary
- add 1px separator line between navigation links and copyright in footer

## Testing
- `npm run lint`
- `npm run build` *(fails: Can't resolve '../../../supabase.local.json')*


------
https://chatgpt.com/codex/tasks/task_e_689dfb5ed3308326b424105ce5be8975