### PR TITLE
Improve responsive layout and language state

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
 import ClientLayout from '@/components/ClientLayout'
+import { LanguageProvider } from '@/lib/i18n'
 
 export const metadata: Metadata = {
   title: 'AnalytiX | Code Groove',
@@ -13,9 +15,14 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="bg-bg text-text antialiased flex min-h-screen flex-col">
-        <ClientLayout>{children}</ClientLayout>
+        <LanguageProvider>
+          <ClientLayout>{children}</ClientLayout>
+        </LanguageProvider>
+        <Script id="lang-init" strategy="beforeInteractive">
+          {`document.documentElement.lang = localStorage.getItem('lang') || 'en';`}
+        </Script>
       </body>
     </html>
   )

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -4,7 +4,6 @@ import { usePathname } from 'next/navigation'
 import { useEffect } from 'react'
 import Navbar from './Navbar'
 import Footer from './Footer'
-import { LanguageProvider } from '@/lib/i18n'
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
@@ -19,11 +18,11 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   }, [pathname])
 
   return (
-    <LanguageProvider>
+    <>
       {showChrome && <Navbar />}
       <div className="flex-1">{children}</div>
       {showChrome && <Footer />}
-    </LanguageProvider>
+    </>
   )
 }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,12 +26,10 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-stroke/60 bg-surface/70 backdrop-blur">
-      <div className="mx-auto max-w-7xl px-4 py-12">
-        {/* Center the whole group */}
+      <div className="relative mx-auto max-w-7xl px-4 py-12">
         <div className="flex flex-wrap items-stretch justify-center gap-8 md:gap-12">
-
           {/* Left: Logo + Socials */}
-          <div className="flex w-full max-w-[260px] sm:w-auto flex-col items-start gap-5 self-stretch justify-center">
+          <div className="flex w-full max-w-[260px] flex-col items-start gap-5 self-stretch justify-center sm:w-auto">
             <Link href="/" aria-label="Analytix Code Groove" className="block w-[160px]">
               <Image src={logo} alt="Analytix Code Groove" width={160} height={46} />
             </Link>
@@ -49,12 +47,8 @@ export default function Footer() {
             </div>
           </div>
 
-          {/* Vertical divider */}
-          <div className="hidden self-stretch w-px bg-stroke/60 sm:block" />
-
           {/* Right: Link columns (Services → Company → Resources) */}
-          {/* Remove flex-1 so it doesn't push to the edges */}
-          <div className="flex flex-wrap items-start gap-x-4 md:gap-x-5 gap-y-5">
+          <div className="flex flex-wrap items-start gap-x-4 gap-y-5 md:gap-x-5">
             {/* Services */}
             <div className="w-[150px] shrink-0">
               <h3 className="mb-1.5 text-[14px] font-semibold text-text">{t('services')}</h3>
@@ -95,6 +89,9 @@ export default function Footer() {
               </ul>
             </div>
           </div>
+
+          {/* Center divider */}
+          <div className="hidden sm:block absolute left-1/2 top-0 h-full w-px -translate-x-1/2 bg-stroke/60" />
         </div>
 
         {/* Bottom border + copyright */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -84,7 +84,7 @@ export default function Navbar() {
             priority
           />
         </Link>
-        <div className="hidden items-center gap-6 md:flex">
+        <div className="hidden flex-1 items-center justify-center gap-6 md:flex">
           {links.map(l => {
             const active = pathname.startsWith(l.href)
             if (l.children) {
@@ -161,7 +161,7 @@ export default function Navbar() {
             )
           })}
         </div>
-        <div className="hidden items-center gap-4 md:flex">
+        <div className="flex items-center gap-4">
           <button
             onClick={() => setLang(lang === 'en' ? 'es' : 'en')}
             className="text-sm text-text/80 transition-colors hover:text-text"
@@ -176,7 +176,7 @@ export default function Navbar() {
           </Link>
           <Link
             href="/contact"
-            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90"
+            className="hidden rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90 sm:inline"
           >
             {t('letsTalk')}
           </Link>


### PR DESCRIPTION
## Summary
- persist selected language across navigation by wrapping layout in a provider and initializing `lang`
- expose language toggle and log-in controls on mobile and adjust contact button visibility
- center footer divider for consistent alignment

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e356a0e108326a5e6f0c408832fdb