### PR TITLE
Align footer with service cards and add favicon

### DIFF
--- a/src/app/favicon.svg
+++ b/src/app/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#23c55e"/>
+  <text x="32" y="44" font-size="44" text-anchor="middle" fill="#fff" font-family="Arial, Helvetica, sans-serif" font-weight="bold">A</text>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,9 @@ import { LanguageProvider } from '@/lib/i18n'
 export const metadata: Metadata = {
   title: 'AnalytiX | Code Groove',
   description: 'Where data meets flow.',
+  icons: {
+    icon: '/favicon.svg',
+  },
 }
 
 export default function RootLayout({

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,9 +27,9 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-stroke/60 bg-surface/70 backdrop-blur">
-      <div className="relative mx-auto max-w-7xl px-4 py-12">
+      <div className="relative mx-auto max-w-7xl py-12">
         {/* Inner wrapper MUST match your cards width (e.g., max-w-5xl or max-w-6xl) */}
-        <div className="mx-auto grid max-w-6xl grid-cols-1 items-start gap-y-8 md:grid-cols-2 md:gap-12">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 items-start gap-y-8 px-4 md:grid-cols-2 md:gap-12">
           {/* Left column: centered logo (shifted to match Services) */}
           <div className="flex justify-center">
             <Link
@@ -99,10 +99,12 @@ export default function Footer() {
         </div>
 
         {/* Divider */}
-        <div className="mt-8 h-px w-full bg-stroke/60" />
+        <div className="mx-auto mt-8 max-w-6xl px-4">
+          <div className="h-px w-full bg-stroke/60" />
+        </div>
 
         {/* Bottom bar: © on the left, socials on the right (aligned to inner width) */}
-        <div className="mx-auto mt-4 flex max-w-6xl items-center justify-between text-xs text-muted">
+        <div className="mx-auto mt-4 flex max-w-6xl items-center justify-between px-4 text-xs text-muted">
           <p>© Analytixcg</p>
           <div className="flex items-center gap-4">
             <a

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -16,7 +16,7 @@ import { useLanguage } from '@/lib/i18n'
 export default function ServiceCards() {
   const { t } = useLanguage()
   return (
-    <section className="bg-bg py-14">
+    <section className="bg-bg py-14 mb-24">
       <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3">
         {cards.map(c => (
           <Link


### PR DESCRIPTION
## Summary
- add a site favicon in SVG format and reference it in layout metadata
- equalize spacing beneath service cards to match above
- align footer content with service card grid edges

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6884cb5c832688f6897fea0f7dcb