### PR TITLE
feat: add IT consulting to services menu

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -107,6 +107,23 @@ const links = [
           </svg>
         ),
       },
+      {
+        href: '/services/consulting',
+        label: 'itConsulting',
+        description: 'itConsultingDesc',
+        icon: (
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="h-5 w-5"
+          >
+            <rect x="3" y="7" width="18" height="13" rx="2" />
+            <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
+          </svg>
+        ),
+      },
     ],
   },
   { href: '/blog', label: 'blog' },


### PR DESCRIPTION
## Summary
- add IT Consulting item to Services dropdown in navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6d1515988326bd71d3ffcdec4c13