### PR TITLE
Add individual service pages

### DIFF
--- a/src/app/services/ai/page.tsx
+++ b/src/app/services/ai/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiCpu, FiZap, FiActivity } from 'react-icons/fi'
+
+export default function AiAutomationPage() {
+  const features = [
+    {
+      icon: FiCpu,
+      title: 'LLM Apps',
+      description: 'Integrate large language models.',
+    },
+    {
+      icon: FiZap,
+      title: 'Automation',
+      description: 'Workflow engines and triggers.',
+    },
+    {
+      icon: FiActivity,
+      title: 'Monitoring',
+      description: 'Observability to keep bots in check.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="aiAutomation"
+      descKey="aiAutomationDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/app/services/analytics/page.tsx
+++ b/src/app/services/analytics/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiPieChart, FiBarChart, FiTrendingUp } from 'react-icons/fi'
+
+export default function AnalyticsPage() {
+  const features = [
+    {
+      icon: FiPieChart,
+      title: 'Dashboards',
+      description: 'Interactive dashboards in real time.',
+    },
+    {
+      icon: FiBarChart,
+      title: 'Visualization',
+      description: 'Visuals that highlight trends.',
+    },
+    {
+      icon: FiTrendingUp,
+      title: 'Insights',
+      description: 'Metrics that drive decisions.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="analytics"
+      descKey="analyticsDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/app/services/apps/page.tsx
+++ b/src/app/services/apps/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiSmartphone, FiCode, FiActivity } from 'react-icons/fi'
+
+export default function AppsApisPage() {
+  const features = [
+    {
+      icon: FiSmartphone,
+      title: 'Frontends',
+      description: 'Mobile-first, accessible UIs.',
+    },
+    {
+      icon: FiCode,
+      title: 'APIs',
+      description: 'Typed, versioned endpoints.',
+    },
+    {
+      icon: FiActivity,
+      title: 'Operations',
+      description: 'Monitoring and telemetry.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="appsApis"
+      descKey="appsApisDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/app/services/consulting/page.tsx
+++ b/src/app/services/consulting/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiMap, FiLayers, FiCompass } from 'react-icons/fi'
+
+export default function ItConsultingPage() {
+  const features = [
+    {
+      icon: FiMap,
+      title: 'Strategy',
+      description: 'Identify opportunities and risks.',
+    },
+    {
+      icon: FiLayers,
+      title: 'Architecture',
+      description: 'Design systems that scale.',
+    },
+    {
+      icon: FiCompass,
+      title: 'Roadmaps',
+      description: 'Plan actionable technology paths.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="itConsulting"
+      descKey="itConsultingDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/app/services/data/page.tsx
+++ b/src/app/services/data/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiDatabase, FiGitBranch, FiCheckCircle } from 'react-icons/fi'
+
+export default function DataEngineeringPage() {
+  const features = [
+    {
+      icon: FiDatabase,
+      title: 'Warehouses',
+      description: 'Streamlined storage for analytics-ready data.',
+    },
+    {
+      icon: FiGitBranch,
+      title: 'Pipelines',
+      description: 'Automated ETL and scheduling.',
+    },
+    {
+      icon: FiCheckCircle,
+      title: 'Quality',
+      description: 'Monitoring and tests for trustworthy data.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="dataEngineering"
+      descKey="dataEngineeringDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/app/services/devops/page.tsx
+++ b/src/app/services/devops/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import ServiceLayout from '@/components/ServiceLayout'
+import { FiCloud, FiRefreshCw, FiLock } from 'react-icons/fi'
+
+export default function CloudDevopsPage() {
+  const features = [
+    {
+      icon: FiCloud,
+      title: 'IaC',
+      description: 'Provision reproducible environments.',
+    },
+    {
+      icon: FiRefreshCw,
+      title: 'CI/CD',
+      description: 'Ship code with automated pipelines.',
+    },
+    {
+      icon: FiLock,
+      title: 'Security',
+      description: 'Built-in policies and guardrails.',
+    },
+  ]
+
+  return (
+    <ServiceLayout
+      titleKey="cloudDevops"
+      descKey="cloudDevopsDesc"
+      features={features}
+    />
+  )
+}
+

--- a/src/components/ServiceLayout.tsx
+++ b/src/components/ServiceLayout.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { IconType } from 'react-icons'
+import { useLanguage } from '@/lib/i18n'
+
+interface Feature {
+  icon: IconType
+  title: string
+  description: string
+}
+
+interface Props {
+  titleKey: string
+  descKey: string
+  features: Feature[]
+}
+
+export default function ServiceLayout({ titleKey, descKey, features }: Props) {
+  const { t } = useLanguage()
+  return (
+    <main className="min-h-screen">
+      <section className="mx-auto grid max-w-5xl items-center gap-8 px-4 py-24 md:grid-cols-2">
+        <div>
+          <h1 className="font-heading text-4xl font-semibold text-text">{t(titleKey)}</h1>
+          <p className="mt-6 text-lg text-muted">{t(descKey)}</p>
+          <div className="mt-8">
+            <Link
+              href="/contact"
+              className="inline-block rounded bg-mint px-6 py-3 font-medium text-bg shadow-soft"
+            >
+              {t('letsTalk')}
+            </Link>
+          </div>
+        </div>
+        <div className="hidden h-72 rounded-xl bg-surface shadow-soft md:block" />
+      </section>
+      <section className="bg-surface py-24">
+        <div className="mx-auto grid max-w-5xl gap-12 px-4 md:grid-cols-3">
+          {features.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="text-center">
+              <Icon className="mx-auto h-12 w-12 text-mint" />
+              <h3 className="mt-4 font-semibold text-text">{title}</h3>
+              <p className="mt-2 text-sm text-muted">{description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- introduce reusable ServiceLayout with hero and feature sections
- apply ServiceLayout to each service page for consistent design

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6ef0dfe08326ab766638a447cfd4