### PR TITLE
feat: split services dropdown into two columns

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -197,7 +197,7 @@ export default function Navbar() {
                       onMouseLeave={closeMenu}
                       className="absolute left-1/2 top-full mt-4 w-80 -translate-x-1/2 rounded-xl border border-stroke/60 bg-surface p-4 shadow-soft"
                     >
-                      <div className="grid gap-4">
+                      <div className="grid grid-flow-col grid-rows-3 gap-4">
                         {l.children.map(child => (
                           <Link
                             key={child.href}


### PR DESCRIPTION
## Summary
- lay out service links in a two-column grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e732279708326bffce8f3e18dadf7