### PR TITLE
Merge data engineering and analytics into unified service

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,10 +9,9 @@ import logo from '@/images/logos/desktop/logo_footer.png'
 
 const services = [
   { href: '/services/ai', label: 'aiAutomation' },
-  { href: '/services/analytics', label: 'analytics' },
   { href: '/services/apps', label: 'appsApis' },
   { href: '/services/devops', label: 'cloudDevops' },
-  { href: '/services/data', label: 'dataEngineering' },
+  { href: '/services/data-analytics', label: 'dataAnalytics' },
   { href: '/services/consulting', label: 'itConsulting' },
 ]
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,9 +14,9 @@ const links = [
     label: 'services',
     children: [
       {
-        href: '/services/data',
-        label: 'dataEngineering',
-        description: 'dataEngineeringDesc',
+        href: '/services/data-analytics',
+        label: 'dataAnalytics',
+        description: 'dataAnalyticsDesc',
         icon: (
           <svg
             viewBox="0 0 24 24"
@@ -44,25 +44,6 @@ const links = [
             className="h-5 w-5"
           >
             <path d="M17 16a4 4 0 0 0 0-8 6 6 0 0 0-11.8 1.46A4 4 0 0 0 6 20h11" />
-          </svg>
-        ),
-      },
-      {
-        href: '/services/analytics',
-        label: 'analytics',
-        description: 'analyticsDesc',
-        icon: (
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className="h-5 w-5"
-          >
-            <path d="M3 3v18h18" />
-            <path d="M7 16V10" />
-            <path d="M12 16V4" />
-            <path d="M17 16v-2" />
           </svg>
         ),
       },

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -19,12 +19,12 @@ export type Service = {
 
 export const services: ReadonlyArray<Service> = [
   {
-    slug: 'data',
-    titleKey: 'dataEngineering',
-    descKey: 'dataEngineeringDesc',
-    cardBlurbKey: 'dataEngineeringCard',
+    slug: 'data-analytics',
+    titleKey: 'dataAnalytics',
+    descKey: 'dataAnalyticsDesc',
+    cardBlurbKey: 'dataAnalyticsCard',
     imageSrc: pic1,
-    imageAlt: 'Data engineering service illustration',
+    imageAlt: 'Data & Analytics service illustration',
     features: [
       {
         icon: 'FiDatabase',
@@ -43,6 +43,21 @@ export const services: ReadonlyArray<Service> = [
         title: 'Quality & Reliability',
         description:
           'Implement validation, monitoring, and lineage tracking so your data remains accurate, trustworthy, and compliant. We ensure every dataset meets your defined SLOs.',
+      },
+      {
+        icon: 'FiPieChart',
+        title: 'Dashboards',
+        description: 'Real-time dashboards for operations and KPIs.',
+      },
+      {
+        icon: 'FiBarChart',
+        title: 'Visualization',
+        description: 'Custom charts that surface trends and anomalies.',
+      },
+      {
+        icon: 'FiTrendingUp',
+        title: 'Insights',
+        description: 'Guidance to turn metrics into decisive action.',
       },
     ],
   },
@@ -68,31 +83,6 @@ export const services: ReadonlyArray<Service> = [
         icon: 'FiActivity',
         title: 'Monitoring',
         description: 'Track drift and performance to keep automation on target.',
-      },
-    ],
-  },
-  {
-    slug: 'analytics',
-    titleKey: 'analytics',
-    descKey: 'analyticsDesc',
-    cardBlurbKey: 'analyticsCard',
-    imageSrc:
-      'https://images.unsplash.com/photo-1556157382-97eda2c9f7e9?auto=format&fit=crop&w=800&q=80',
-    features: [
-      {
-        icon: 'FiPieChart',
-        title: 'Dashboards',
-        description: 'Real-time dashboards for operations and KPIs.',
-      },
-      {
-        icon: 'FiBarChart',
-        title: 'Visualization',
-        description: 'Custom charts that surface trends and anomalies.',
-      },
-      {
-        icon: 'FiTrendingUp',
-        title: 'Insights',
-        description: 'Guidance to turn metrics into decisive action.',
       },
     ],
   },

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -7,9 +7,9 @@ type Language = 'en' | 'es'
 const translations: Record<Language, Record<string, string>> = {
   en: {
     about: 'About',
-    dataEngineering: 'Data Engineering',
-    dataEngineeringDesc: 'ETL pipelines & warehouses',
-    dataEngineeringCard: 'Pipelines, orchestration, quality, SLOs.',
+    dataAnalytics: 'Data & Analytics',
+    dataAnalyticsDesc: 'Platforms, pipelines & dashboards',
+    dataAnalyticsCard: 'Warehouses, ETL, visualization, insights.',
     cloudDevops: 'Cloud & DevOps',
     cloudDevopsDesc: 'Infra automation & reliability',
     cloudDevopsCard: 'AWS, IaC, CI/CD, cost-safe scaling.',
@@ -27,9 +27,6 @@ const translations: Record<Language, Record<string, string>> = {
     flow: 'Flow',
     heroParagraph:
       'We build reliable data platforms and production-grade apps—fast, observable, secure. Less friction, more groove.',
-    analytics: 'Analytics',
-    analyticsDesc: 'Dashboards & visualization',
-    analyticsCard: 'Dashboards that drive decisions.',
     aiAutomation: 'AI / Automation',
     aiAutomationDesc: 'LLMs, agents & automation',
     aiAutomationCard: 'LLMs, agents, workflow automation.',
@@ -59,9 +56,9 @@ const translations: Record<Language, Record<string, string>> = {
   },
   es: {
     about: 'Acerca de',
-    dataEngineering: 'Ingeniería de Datos',
-    dataEngineeringDesc: 'Pipelines ETL y almacenes',
-    dataEngineeringCard: 'Pipelines, orquestación, calidad, SLOs.',
+    dataAnalytics: 'Datos y Analítica',
+    dataAnalyticsDesc: 'Plataformas, pipelines y dashboards',
+    dataAnalyticsCard: 'Almacenes, ETL, visualización e insights.',
     cloudDevops: 'Nube y DevOps',
     cloudDevopsDesc: 'Infra automatizada y confiable',
     cloudDevopsCard: 'AWS, IaC, CI/CD, escalado rentable.',
@@ -79,9 +76,6 @@ const translations: Record<Language, Record<string, string>> = {
     flow: 'Flow',
     heroParagraph:
       'Construimos plataformas de datos confiables y aplicaciones de producción: rápidas, observables y seguras. Menos fricción, más ritmo.',
-    analytics: 'Analítica',
-    analyticsDesc: 'Paneles y visualización',
-    analyticsCard: 'Paneles que impulsan decisiones.',
     aiAutomation: 'IA / Automatización',
     aiAutomationDesc: 'LLMs, agentes y automatización',
     aiAutomationCard: 'LLMs, agentes, automatización de flujos.',


### PR DESCRIPTION
## Summary
- Replace separate Data Engineering and Analytics offerings with a combined **Data & Analytics** service
- Remove outdated navigation and footer links to the standalone analytics page
- Update translations to reflect the new service name and description

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f2b8661e0832691f57689218595bd