### PR TITLE
feat: expand cloud and devops service

### DIFF
--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -5,7 +5,11 @@ import { notFound } from 'next/navigation'
 export function generateStaticParams() {
   return services
     .filter(
-      s => s.slug !== 'data-analytics' && s.slug !== 'ai' && s.slug !== 'apps'
+      s =>
+        s.slug !== 'data-analytics' &&
+        s.slug !== 'ai' &&
+        s.slug !== 'apps' &&
+        s.slug !== 'devops'
     )
     .map(s => ({ slug: s.slug }))
 }

--- a/src/app/services/devops/page.tsx
+++ b/src/app/services/devops/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Cloud & DevOps Services | AnalytiX',
+  description: 'Build, deploy, and scale with confidence.',
+}
+
+export default function CloudDevOpsServicePage() {
+  return (
+    <main className="min-h-screen">
+      {/* Hero */}
+      <section className="mx-auto max-w-5xl px-4 py-28">
+        <h1 className="font-heading text-4xl font-semibold text-text">
+          Cloud & DevOps Services
+        </h1>
+        <p className="mt-6 text-lg text-muted">
+          Build, deploy, and scale with confidence.
+        </p>
+        <div className="mt-8">
+          <Link
+            href="/contact"
+            className="inline-block rounded bg-mint px-6 py-3 font-medium text-bg shadow-soft"
+          >
+            Let’s talk
+          </Link>
+        </div>
+      </section>
+
+      {/* Why Cloud & DevOps */}
+      <section className="bg-surface py-24">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 className="text-2xl font-semibold text-text">
+            Why Cloud & DevOps Matter for Your Business
+          </h2>
+          <p className="mt-8 text-muted">
+            Modern businesses can’t afford slow deployments, fragile infrastructure, or scaling bottlenecks. Cloud and DevOps practices transform how you deliver technology—shortening release cycles, improving reliability, and enabling cost-efficient growth.
+          </p>
+          <p className="mt-4 text-muted">
+            From infrastructure-as-code to automated CI/CD pipelines, Cloud & DevOps keep your systems resilient, secure, and ready to adapt to changing business demands.
+          </p>
+        </div>
+      </section>
+
+      {/* Approach */}
+      <section className="py-24">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 className="text-2xl font-semibold text-text">
+            Our Practical, Value-First Approach
+          </h2>
+          <p className="mt-4 text-muted">
+            We focus on DevOps and cloud strategies that deliver measurable outcomes, not just tool adoption. Whether migrating to the cloud, optimizing an existing environment, or embedding DevOps culture into your teams, our goal is to create infrastructure and workflows that scale without adding complexity.
+          </p>
+          <p className="mt-4 text-muted">
+            We combine cloud architecture best practices with automation to ensure performance, security, and cost-effectiveness—so your technology works harder for you, not the other way around.
+          </p>
+        </div>
+      </section>
+
+      {/* How We Deliver */}
+      <section className="bg-surface py-24">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 className="text-2xl font-semibold text-text">
+            How We Deliver (Clear, Actionable Focus)
+          </h2>
+          <ol className="mt-8 list-decimal space-y-6 pl-5 text-muted">
+            <li>
+              <span className="font-medium text-text">Assess &amp; Align –</span> Understand your infrastructure, delivery challenges, and business priorities.
+            </li>
+            <li>
+              <span className="font-medium text-text">Design for Scale &amp; Security –</span> Architect cloud-native or hybrid solutions built for resilience and compliance.
+            </li>
+            <li>
+              <span className="font-medium text-text">Automate Delivery –</span> Implement CI/CD pipelines, automated testing, and deployment workflows.
+            </li>
+            <li>
+              <span className="font-medium text-text">Infrastructure as Code (IaC) –</span> Use tools like Terraform, CloudFormation, or Pulumi for repeatable, reliable provisioning.
+            </li>
+            <li>
+              <span className="font-medium text-text">Optimize &amp; Monitor –</span> Leverage observability, cost analysis, and performance tuning to ensure your environment evolves with your needs.
+            </li>
+            <li>
+              <span className="font-medium text-text">Embed DevOps Culture –</span> Coach teams to adopt best practices that sustain long-term agility and quality.
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      {/* Outcomes */}
+      <section className="py-24">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 className="text-2xl font-semibold text-text">Outcomes You Can Count On</h2>
+          <p className="mt-4 text-muted">We partner with you to:</p>
+          <ul className="mt-8 list-disc space-y-4 pl-5 text-muted">
+            <li>
+              <span className="font-medium text-text">Accelerate Releases –</span> Ship features faster without compromising stability.
+            </li>
+            <li>
+              <span className="font-medium text-text">Improve Reliability –</span> Design systems that self-heal and recover quickly from failures.
+            </li>
+            <li>
+              <span className="font-medium text-text">Control Costs –</span> Optimize resource usage with right-sizing, automation, and governance.
+            </li>
+            <li>
+              <span className="font-medium text-text">Increase Agility –</span> Enable teams to adapt quickly to market and customer needs.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add dedicated Cloud & DevOps services page with detailed messaging
- exclude devops from generic service generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Can't resolve '../../../supabase.local.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f3f2e62b0832696d10304c99003fa