### PR TITLE
feat: add SEO metadata and RSS feed

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'About | AnalytiX',
+  description: 'Learn more about AnalytiX and our mission to align data with execution.',
+}
+
 export default function AboutPage() {
   return (
     <main className="min-h-screen">

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
+
+export const metadata: Metadata = {
+  title: 'Auth Redirect | AnalytiX',
+  description: 'Redirecting to the login page.',
+}
 
 export default function AuthPage() {
   redirect('/login')

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,10 +1,13 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+import { posts } from '@/data/posts'
+
+export const metadata: Metadata = {
+  title: 'Blog | AnalytiX',
+  description: 'Insights on data engineering, cloud, and automation from the AnalytiX team.',
+}
 
 export default function BlogPage() {
-  const posts = [
-    { slug: 'databricks-pipeline-slos', title: 'SLOs for Data Pipelines', excerpt: 'Designing reliability you can measure.' },
-    { slug: 'aws-step-functions-observability', title: 'Observability for Step Functions', excerpt: 'Metrics that matter.' },
-  ]
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">

--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { useEffect, useState } from 'react'
 import { createSupabaseBrowserClient } from '../../lib/supabase'
 
@@ -11,6 +12,11 @@ const merge = (local: Bookmark[], server: Bookmark[]): Bookmark[] => {
   const map = new Map(local.map(b => [b.url, b]))
   server.forEach(b => map.set(b.url, b))
   return Array.from(map.values())
+}
+
+export const metadata: Metadata = {
+  title: 'Bookmarks | AnalytiX',
+  description: 'Save and manage your favorite links in AnalytiX.',
 }
 
 export default function BookmarksPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Contact | AnalytiX',
+  description: 'Get in touch with the AnalytiX team to discuss your next project.',
+}
+
 export default function ContactPage() {
   return (
     <main className="min-h-screen">

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Forgot Password | AnalytiX',
+  description: 'Recover access to your AnalytiX account.',
+}
+
 export default function ForgotPasswordPage() {
   return (
     <main className="bg-bg flex min-h-screen items-center justify-center px-4">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,11 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.svg',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': '/rss.xml',
+    },
+  },
 }
 
 export default function RootLayout({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -9,6 +10,11 @@ import { useLanguage } from '@/lib/i18n'
 import { createSupabaseBrowserClient } from '@/lib/supabase'
 import supabaseConfig from '../../../supabase.local.json'
 import logo from '@/images/logos/desktop/logo_login.png'
+
+export const metadata: Metadata = {
+  title: 'Log In | AnalytiX',
+  description: 'Access your AnalytiX account to manage services and bookmarks.',
+}
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from 'next'
 import Hero from '@/components/Hero'
 import ServiceCards from '@/components/ServiceCards'
+
+export const metadata: Metadata = {
+  title: 'Home | AnalytiX',
+  description: 'Discover our data, AI, and cloud services designed to move your business forward.',
+}
 
 export default function Home() {
   return (

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,16 @@
+import { posts } from '@/data/posts'
+
+export async function GET() {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const items = posts
+    .map(p => `    <item>\n      <title>${p.title}</title>\n      <link>${baseUrl}/blog/${p.slug}</link>\n      <description>${p.excerpt}</description>\n    </item>`)    
+    .join('\n')
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">\n  <channel>\n    <title>AnalytiX Blog</title>\n    <link>${baseUrl}/blog</link>\n    <description>Latest posts from the AnalytiX blog.</description>\n${items}\n  </channel>\n</rss>`
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml',
+    },
+  })
+}

--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -1,6 +1,11 @@
+import type { Metadata } from 'next'
 import ServiceLayout from '@/components/ServiceLayout'
 import { getService, services } from '@/data/services'
 import { notFound } from 'next/navigation'
+
+interface Params {
+  slug: string
+}
 
 export function generateStaticParams() {
   return services
@@ -9,14 +14,20 @@ export function generateStaticParams() {
         s.slug !== 'data-analytics' &&
         s.slug !== 'ai' &&
         s.slug !== 'apps' &&
-        s.slug !== 'consulting'
+        s.slug !== 'consulting' &&
         s.slug !== 'devops'
     )
     .map(s => ({ slug: s.slug }))
 }
 
-interface Params {
-  slug: string
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const service = getService(params.slug)
+  const name = service?.slug.replace(/-/g, ' ') ?? 'service'
+  const title = `${name.charAt(0).toUpperCase() + name.slice(1)} | AnalytiX`
+  const description = service
+    ? `Learn more about our ${name} offering.`
+    : 'Service details.'
+  return { title, description }
 }
 
 export default async function ServicePage({ params }: { params: Promise<Params> }) {

--- a/src/app/services/ai/page.tsx
+++ b/src/app/services/ai/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Generative AI Services | AnalytiX',
+  description: 'Where automation meets creativity to solve real-world challenges.',
+}
 
 export default function GenerativeAIServicePage() {
   return (

--- a/src/app/services/consulting/page.tsx
+++ b/src/app/services/consulting/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'IT Consulting | AnalytiX',
+  description: 'Clarity, architecture, and momentum—when you need it.',
+}
 
 export default function ITConsultingServicePage() {
   return (

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next'
 import ServiceCards from '@/components/ServiceCards'
+
+export const metadata: Metadata = {
+  title: 'Services | AnalytiX',
+  description: 'Explore the range of technology services offered by AnalytiX.',
+}
 
 export default function ServicesPage() {
   return (

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,9 +1,15 @@
 'use client'
 
+import type { Metadata } from 'next'
 import { useState } from 'react'
 import Link from 'next/link'
 
 import { createSupabaseBrowserClient } from '../../lib/supabase'
+
+export const metadata: Metadata = {
+  title: 'Sign Up | AnalytiX',
+  description: 'Create your AnalytiX account with email or social providers.',
+}
 
 export default function SignupPage() {
   const [email, setEmail] = useState('')

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,0 +1,10 @@
+export type Post = {
+  slug: string
+  title: string
+  excerpt: string
+}
+
+export const posts: ReadonlyArray<Post> = [
+  { slug: 'databricks-pipeline-slos', title: 'SLOs for Data Pipelines', excerpt: 'Designing reliability you can measure.' },
+  { slug: 'aws-step-functions-observability', title: 'Observability for Step Functions', excerpt: 'Metrics that matter.' },
+]


### PR DESCRIPTION
## Summary
- add page-level metadata for SEO
- expose RSS feed for blog posts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f423c2a9883269e18b80b09ebf9b8