### PR TITLE
Add info section and localization for pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { Metadata } from 'next'
+import { useLanguage } from '@/lib/i18n'
 
 export const metadata: Metadata = {
   title: 'About | AnalytiX',
@@ -6,11 +9,12 @@ export const metadata: Metadata = {
 }
 
 export default function AboutPage() {
+  const { t } = useLanguage()
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">About</h1>
-        <p className="mt-4 text-muted">Coming soon...</p>
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('about')}</h1>
+        <p className="mt-4 text-muted">{t('comingSoon')}</p>
       </div>
     </main>
   )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,9 @@
+"use client"
+
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { posts } from '@/data/posts'
+import { useLanguage } from '@/lib/i18n'
 
 export const metadata: Metadata = {
   title: 'Blog | AnalytiX',
@@ -8,16 +11,21 @@ export const metadata: Metadata = {
 }
 
 export default function BlogPage() {
+  const { t } = useLanguage()
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">Blog</h1>
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('blog')}</h1>
         <div className="mt-8 grid gap-6 sm:grid-cols-2">
           {posts.map(p => (
-            <Link key={p.slug} href={`/blog/${p.slug}`} className="rounded-xl2 border border-stroke/70 bg-surface p-6 hover:border-mint/60">
+            <Link
+              key={p.slug}
+              href={`/blog/${p.slug}`}
+              className="rounded-xl2 border border-stroke/70 bg-surface p-6 transition hover:border-mint/60"
+            >
               <h3 className="font-heading text-text">{p.title}</h3>
               <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
-              <span className="mt-3 block text-sm text-mint">Read →</span>
+              <span className="mt-3 block text-sm text-mint">{t('readMore')}</span>
             </Link>
           ))}
         </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { Metadata } from 'next'
+import { useLanguage } from '@/lib/i18n'
 
 export const metadata: Metadata = {
   title: 'Contact | AnalytiX',
@@ -6,11 +9,17 @@ export const metadata: Metadata = {
 }
 
 export default function ContactPage() {
+  const { t } = useLanguage()
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">Contact</h1>
-        <p className="mt-4 text-muted">Reach us at <a href="mailto:hello@example.com" className="text-mint">hello@example.com</a></p>
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('contact')}</h1>
+        <p className="mt-4 text-muted">
+          {t('reachUsAt')}{' '}
+          <a href="mailto:hello@example.com" className="text-mint">
+            hello@example.com
+          </a>
+        </p>
       </div>
     </main>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Hero from '@/components/Hero'
 import ServiceCards from '@/components/ServiceCards'
+import MoreInfo from '@/components/MoreInfo'
 import LatestPosts from '@/components/LatestPosts'
 
 export const metadata: Metadata = {
@@ -13,6 +14,7 @@ export default function Home() {
     <main>
       <Hero />
       <ServiceCards />
+      <MoreInfo />
       <LatestPosts />
     </main>
   )

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { Metadata } from 'next'
+import { useLanguage } from '@/lib/i18n'
 import ServiceCards from '@/components/ServiceCards'
 
 export const metadata: Metadata = {
@@ -7,10 +10,11 @@ export const metadata: Metadata = {
 }
 
 export default function ServicesPage() {
+  const { t } = useLanguage()
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">Services</h1>
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('services')}</h1>
       </div>
       <ServiceCards />
     </main>

--- a/src/components/LatestPosts.tsx
+++ b/src/components/LatestPosts.tsx
@@ -13,14 +13,16 @@ export default function LatestPosts() {
           {t('latestPosts')}
         </h2>
         <div className="grid gap-6 sm:grid-cols-2">
-          {posts.map(p => (
-            <article key={p.slug} className="rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
-              <h3 className="text-lg font-semibold text-text">{p.title}</h3>
+          {posts.slice(0, 2).map(p => (
+            <Link
+              key={p.slug}
+              href={`/blog/${p.slug}`}
+              className="group rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft transition hover:border-mint/60"
+            >
+              <h3 className="text-lg font-semibold text-text group-hover:text-mint">{p.title}</h3>
               <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
-              <Link href={`/blog/${p.slug}`} className="mt-4 inline-block text-sm text-mint">
-                {t('readMore')}
-              </Link>
-            </article>
+              <span className="mt-4 inline-block text-sm text-mint">{t('readMore')}</span>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useLanguage } from '@/lib/i18n'
+
+export default function MoreInfo() {
+  const { t } = useLanguage()
+  return (
+    <section className="bg-bg py-14">
+      <div className="mx-auto max-w-6xl px-4">
+        <h2 className="mb-4 font-heading text-2xl font-semibold text-text">{t('moreInfoHeading')}</h2>
+        <p className="text-muted">{t('moreInfoBody')}</p>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -22,6 +22,11 @@ const translations: Record<Language, Record<string, string>> = {
     letsTalk: "Let’s talk",
     seeServices: 'See services',
     readBlog: 'Read the blog',
+    comingSoon: 'Coming soon...',
+    reachUsAt: 'Reach us at',
+    moreInfoHeading: 'Why AnalytiX?',
+    moreInfoBody:
+      'From data foundations to AI, we guide you from idea to production with a battle-tested team.',
     latestPosts: 'Latest posts',
     readMore: 'Read more →',
     whereData: 'Where Data',
@@ -76,6 +81,11 @@ const translations: Record<Language, Record<string, string>> = {
     letsTalk: 'Hablemos',
     seeServices: 'Ver servicios',
     readBlog: 'Leer el blog',
+    comingSoon: 'Próximamente...',
+    reachUsAt: 'Contáctanos en',
+    moreInfoHeading: '¿Por qué AnalytiX?',
+    moreInfoBody:
+      'Desde bases de datos hasta IA, te ayudamos a llevar las ideas a producción con un equipo experimentado.',
     latestPosts: 'Últimas publicaciones',
     readMore: 'Leer más →',
     whereData: 'Where Data',


### PR DESCRIPTION
## Summary
- limit latest posts to two with service-card hover effect
- insert informational section between services and blog preview
- localize about, contact, services, and blog pages with new i18n strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f5165fa848326b526fc250103721b