### PR TITLE
Add bottom spacing after latest posts section

### DIFF
--- a/src/components/LatestPosts.tsx
+++ b/src/components/LatestPosts.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from '@/lib/i18n'
 export default function LatestPosts() {
   const { t } = useLanguage()
   return (
-    <section className="bg-bg py-14">
+    <section className="bg-bg py-14 mb-24">
       <div className="mx-auto max-w-6xl px-4">
         <h2 className="mb-8 font-heading text-2xl font-semibold text-text">
           {t('latestPosts')}


### PR DESCRIPTION
## Summary
- ensure consistent spacing after Latest Posts section by adding bottom margin

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f60620058832687f0e0eefda753a6