### PR TITLE
feat: flesh out Analytix Code Groove about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,8 +4,9 @@ import type { Metadata } from 'next'
 import { useLanguage } from '@/lib/i18n'
 
 export const metadata: Metadata = {
-  title: 'About | AnalytiX',
-  description: 'Learn more about AnalytiX and our mission to align data with execution.',
+  title: 'About | Analytix Code Groove',
+  description:
+    'Discover Analytix Code Groove’s mission and values in empowering teams with data-driven applications.',
 }
 
 export default function AboutPage() {
@@ -14,7 +15,21 @@ export default function AboutPage() {
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
         <h1 className="font-heading text-3xl font-semibold text-text">{t('about')}</h1>
-        <p className="mt-4 text-muted">{t('comingSoon')}</p>
+        <p className="mt-4 text-muted">{t('aboutIntro')}</p>
+        <div className="mt-8 space-y-8">
+          <section>
+            <h2 className="font-heading text-2xl font-semibold text-text">
+              {t('missionHeading')}
+            </h2>
+            <p className="mt-2 text-muted">{t('missionBody')}</p>
+          </section>
+          <section>
+            <h2 className="font-heading text-2xl font-semibold text-text">
+              {t('valuesHeading')}
+            </h2>
+            <p className="mt-2 text-muted">{t('valuesBody')}</p>
+          </section>
+        </div>
       </div>
     </main>
   )

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -23,6 +23,14 @@ const translations: Record<Language, Record<string, string>> = {
     seeServices: 'See services',
     readBlog: 'Read the blog',
     comingSoon: 'Coming soon...',
+    aboutIntro:
+      'Analytix Code Groove blends data expertise with modern software craftsmanship to turn ideas into scalable reality.',
+    missionHeading: 'Our Mission',
+    missionBody:
+      'Enable teams to groove with their data, transforming information into insight and action with clarity and speed.',
+    valuesHeading: 'What We Value',
+    valuesBody:
+      'Pragmatic engineering, transparent collaboration, and measurable outcomes that move businesses forward.',
     reachUsAt: 'Reach us at',
     moreInfoHeading: 'Why AnalytiX?',
     moreInfoBody:
@@ -82,6 +90,14 @@ const translations: Record<Language, Record<string, string>> = {
     seeServices: 'Ver servicios',
     readBlog: 'Leer el blog',
     comingSoon: 'Próximamente...',
+    aboutIntro:
+      'Analytix Code Groove combina el dominio de datos con la artesanía moderna de software. Ayudamos a los equipos a convertir ideas en productos fiables y escalables.',
+    missionHeading: 'Nuestra Misión',
+    missionBody:
+      'Permitir que las organizaciones fluyan con sus datos, transformando información en conocimiento y acción con claridad y rapidez.',
+    valuesHeading: 'Lo que Valoramos',
+    valuesBody:
+      'Creemos en la ingeniería pragmática, la colaboración transparente y los resultados medibles que impulsan a las empresas.',
     reachUsAt: 'Contáctanos en',
     moreInfoHeading: '¿Por qué AnalytiX?',
     moreInfoBody:


### PR DESCRIPTION
## Summary
- expand About page with mission and values for Analytix Code Groove
- add English and Spanish translations for new content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f60712b3c83269146227c65e5f374