### PR TITLE
refactor: move metadata to server components

### DIFF
--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import Link from 'next/link'
+import { posts } from '@/data/posts'
+import { useLanguage } from '@/lib/i18n'
+
+export default function BlogClient() {
+  const { t } = useLanguage()
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('blog')}</h1>
+        <div className="mt-8 grid gap-6 sm:grid-cols-2">
+          {posts.map(p => (
+            <Link
+              key={p.slug}
+              href={`/blog/${p.slug}`}
+              className="rounded-xl2 border border-stroke/70 bg-surface p-6 transition hover:border-mint/60"
+            >
+              <h3 className="font-heading text-text">{p.title}</h3>
+              <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
+              <span className="mt-3 block text-sm text-mint">{t('readMore')}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,9 +1,5 @@
-"use client"
-
 import type { Metadata } from 'next'
-import Link from 'next/link'
-import { posts } from '@/data/posts'
-import { useLanguage } from '@/lib/i18n'
+import BlogClient from './BlogClient'
 
 export const metadata: Metadata = {
   title: 'Blog | AnalytiX',
@@ -11,25 +7,5 @@ export const metadata: Metadata = {
 }
 
 export default function BlogPage() {
-  const { t } = useLanguage()
-  return (
-    <main className="min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">{t('blog')}</h1>
-        <div className="mt-8 grid gap-6 sm:grid-cols-2">
-          {posts.map(p => (
-            <Link
-              key={p.slug}
-              href={`/blog/${p.slug}`}
-              className="rounded-xl2 border border-stroke/70 bg-surface p-6 transition hover:border-mint/60"
-            >
-              <h3 className="font-heading text-text">{p.title}</h3>
-              <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
-              <span className="mt-3 block text-sm text-mint">{t('readMore')}</span>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </main>
-  )
+  return <BlogClient />
 }

--- a/src/app/contact/ContactClient.tsx
+++ b/src/app/contact/ContactClient.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useLanguage } from '@/lib/i18n'
+
+export default function ContactClient() {
+  const { t } = useLanguage()
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('contact')}</h1>
+        <p className="mt-4 text-muted">
+          {t('reachUsAt')}{' '}
+          <a href="mailto:hello@example.com" className="text-mint">
+            hello@example.com
+          </a>
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,7 +1,5 @@
-"use client"
-
 import type { Metadata } from 'next'
-import { useLanguage } from '@/lib/i18n'
+import ContactClient from './ContactClient'
 
 export const metadata: Metadata = {
   title: 'Contact | AnalytiX',
@@ -9,18 +7,5 @@ export const metadata: Metadata = {
 }
 
 export default function ContactPage() {
-  const { t } = useLanguage()
-  return (
-    <main className="min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">{t('contact')}</h1>
-        <p className="mt-4 text-muted">
-          {t('reachUsAt')}{' '}
-          <a href="mailto:hello@example.com" className="text-mint">
-            hello@example.com
-          </a>
-        </p>
-      </div>
-    </main>
-  )
+  return <ContactClient />
 }

--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useLanguage } from '@/lib/i18n'
+import ServiceCards from '@/components/ServiceCards'
+
+export default function ServicesClient() {
+  const { t } = useLanguage()
+  return (
+    <main className="min-h-screen">
+      <div className="mx-auto max-w-5xl px-4 py-16">
+        <h1 className="font-heading text-3xl font-semibold text-text">{t('services')}</h1>
+      </div>
+      <ServiceCards />
+    </main>
+  )
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,8 +1,5 @@
-"use client"
-
 import type { Metadata } from 'next'
-import { useLanguage } from '@/lib/i18n'
-import ServiceCards from '@/components/ServiceCards'
+import ServicesClient from './ServicesClient'
 
 export const metadata: Metadata = {
   title: 'Services | AnalytiX',
@@ -10,13 +7,5 @@ export const metadata: Metadata = {
 }
 
 export default function ServicesPage() {
-  const { t } = useLanguage()
-  return (
-    <main className="min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">{t('services')}</h1>
-      </div>
-      <ServiceCards />
-    </main>
-  )
+  return <ServicesClient />
 }

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -247,15 +247,17 @@ const LanguageContext = createContext<LanguageContextProps | undefined>(
 )
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [lang, setLangState] = useState<Language>(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('lang') as Language | null
-      if (stored) return stored
+  const [lang, setLangState] = useState<Language>('en')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lang') as Language | null
+    if (stored) {
+      setLangState(stored)
+    } else {
       const browser = navigator.language.slice(0, 2)
-      if (browser === 'es') return 'es'
+      if (browser === 'es') setLangState('es')
     }
-    return 'en'
-  })
+  }, [])
 
   useEffect(() => {
     document.documentElement.lang = lang


### PR DESCRIPTION
## Summary
- fix blog page metadata by moving client logic into `BlogClient`
- refactor contact and services pages to use client subcomponents
- prevent hydration mismatches by deferring language detection to client mount

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f66d2bff8832698cd0ebe47a52051