### PR TITLE
Add translations for signup, bookmarks and password reset pages

### DIFF
--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { createSupabaseBrowserClient } from '../../lib/supabase'
+import { useLanguage } from '@/lib/i18n'
 
 type Bookmark = {
   url: string
@@ -18,6 +19,7 @@ export default function BookmarksPage() {
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([])
   const [url, setUrl] = useState('')
   const supabase = typeof window !== 'undefined' ? createSupabaseBrowserClient() : null
+  const { t } = useLanguage()
 
   const loadLocal = (): Bookmark[] => {
     try {
@@ -76,7 +78,7 @@ export default function BookmarksPage() {
 
   return (
     <main className="bg-bg min-h-screen p-4 text-text">
-      <h1 className="mb-4 text-2xl font-semibold">Bookmarks</h1>
+      <h1 className="mb-4 text-2xl font-semibold">{t('bookmarks')}</h1>
       <form onSubmit={addBookmark} className="mb-4 flex gap-2">
         <input
           type="url"
@@ -89,11 +91,11 @@ export default function BookmarksPage() {
           type="submit"
           className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
         >
-          Add
+          {t('add')}
         </button>
       </form>
       {bookmarks.length === 0 ? (
-        <p className="text-sm text-text/80">No bookmarks yet.</p>
+        <p className="text-sm text-text/80">{t('noBookmarksYet')}</p>
       ) : (
         <ul className="space-y-2">
           {bookmarks.map(b => (

--- a/src/app/forgot-password/ForgotPasswordClient.tsx
+++ b/src/app/forgot-password/ForgotPasswordClient.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useLanguage } from '@/lib/i18n'
+
+export default function ForgotPasswordClient() {
+  const { t } = useLanguage()
+  return (
+    <main className="bg-bg flex min-h-screen items-center justify-center px-4">
+      <form className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
+        <h1 className="text-2xl font-semibold text-text">{t('recoverPassword')}</h1>
+        <div className="mt-4 flex flex-col gap-4">
+          <input
+            type="email"
+            placeholder={t('emailPlaceholder')}
+            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
+          />
+          <button
+            type="submit"
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            {t('sendResetLink')}
+          </button>
+        </div>
+        <p className="mt-4 text-sm">
+          <a href="/login" className="text-mint hover:underline">
+            {t('backToLogin')}
+          </a>
+        </p>
+      </form>
+    </main>
+  )
+}
+

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import ForgotPasswordClient from './ForgotPasswordClient'
 
 export const metadata: Metadata = {
   title: 'Forgot Password | AnalytiX',
@@ -6,29 +7,6 @@ export const metadata: Metadata = {
 }
 
 export default function ForgotPasswordPage() {
-  return (
-    <main className="bg-bg flex min-h-screen items-center justify-center px-4">
-      <form className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
-        <h1 className="text-2xl font-semibold text-text">Recover password</h1>
-        <div className="mt-4 flex flex-col gap-4">
-          <input
-            type="email"
-            placeholder="Email"
-            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
-          />
-          <button
-            type="submit"
-            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
-          >
-            Send reset link
-          </button>
-        </div>
-        <p className="mt-4 text-sm">
-          <a href="/login" className="text-mint hover:underline">
-            Back to log in
-          </a>
-        </p>
-      </form>
-    </main>
-  )
+  return <ForgotPasswordClient />
 }
+

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useLanguage } from '@/lib/i18n'
 
 import { createSupabaseBrowserClient } from '../../lib/supabase'
 
@@ -9,12 +10,13 @@ import { createSupabaseBrowserClient } from '../../lib/supabase'
 export default function SignupPage() {
   const [email, setEmail] = useState('')
   const [message, setMessage] = useState('')
+  const { t } = useLanguage()
 
   const handleEmailSignup = async (e: React.FormEvent) => {
     e.preventDefault()
     const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOtp({ email })
-    setMessage(error ? error.message : 'Check your email for the signup link.')
+    setMessage(error ? error.message : t('checkEmailForLink'))
   }
 
   const handleProviderSignup = (provider: 'google' | 'github') => async () => {
@@ -26,41 +28,41 @@ export default function SignupPage() {
   return (
     <main className="bg-bg flex min-h-screen items-center justify-center px-4">
       <form onSubmit={handleEmailSignup} className="w-full max-w-md rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft">
-        <h1 className="text-2xl font-semibold text-text">Sign up</h1>
+        <h1 className="text-2xl font-semibold text-text">{t('signUp')}</h1>
         <div className="mt-4 flex flex-col gap-4">
           <input
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="Email"
+            onChange={e => setEmail(e.target.value)}
+            placeholder={t('emailPlaceholder')}
             className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
           />
           <button
             type="submit"
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Send magic link
+            {t('sendMagicLink')}
           </button>
           <button
             type="button"
             onClick={handleProviderSignup('google')}
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Sign up with Google
+            {t('signUpWithGoogle')}
           </button>
           <button
             type="button"
             onClick={handleProviderSignup('github')}
             className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
           >
-            Sign up with GitHub
+            {t('signUpWithGithub')}
           </button>
           {message && <p className="text-sm text-text">{message}</p>}
         </div>
         <p className="mt-4 text-sm">
-          Already have an account?{' '}
+          {t('alreadyHaveAccount')}{' '}
           <Link href="/login" className="text-mint hover:underline">
-            Log in
+            {t('login')}
           </Link>
         </p>
       </form>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -116,6 +116,18 @@ const translations: Record<Language, Record<string, string>> = {
     signUpNow: 'Sign Up Now',
     termsAgreement:
       "By continuing, you agree to Analytix's Terms of Service and Privacy Policy, and to receive periodic emails with updates.",
+    recoverPassword: 'Recover password',
+    sendResetLink: 'Send reset link',
+    backToLogin: 'Back to log in',
+    signUp: 'Sign up',
+    sendMagicLink: 'Send magic link',
+    signUpWithGoogle: 'Sign up with Google',
+    signUpWithGithub: 'Sign up with GitHub',
+    checkEmailForLink: 'Check your email for the signup link.',
+    alreadyHaveAccount: 'Already have an account?',
+    bookmarks: 'Bookmarks',
+    add: 'Add',
+    noBookmarksYet: 'No bookmarks yet.',
   },
   es: {
     about: 'Acerca de',
@@ -233,6 +245,18 @@ const translations: Record<Language, Record<string, string>> = {
     signUpNow: 'Regístrate ahora',
     termsAgreement:
       'Al continuar, aceptas los Términos de Servicio y la Política de Privacidad de Analytix, y autorizas el envío de correos electrónicos periódicos con actualizaciones.',
+    recoverPassword: 'Recuperar contraseña',
+    sendResetLink: 'Enviar enlace de restablecimiento',
+    backToLogin: 'Volver a iniciar sesión',
+    signUp: 'Registrarse',
+    sendMagicLink: 'Enviar enlace mágico',
+    signUpWithGoogle: 'Registrarse con Google',
+    signUpWithGithub: 'Registrarse con GitHub',
+    checkEmailForLink: 'Revisa tu correo para el enlace de registro.',
+    alreadyHaveAccount: '¿Ya tienes una cuenta?',
+    bookmarks: 'Marcadores',
+    add: 'Agregar',
+    noBookmarksYet: 'Aún no hay marcadores.',
   },
 }
 


### PR DESCRIPTION
## Summary
- localize signup form strings and provider buttons
- translate bookmarks page UI
- add password reset client component with translations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f7911567c8326b29a26a0d2408713