### PR TITLE
Revamp About page styling

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,29 +1,45 @@
 "use client"
 
+import Link from 'next/link'
+import { FiHeart, FiTarget } from 'react-icons/fi'
 import { useLanguage } from '@/lib/i18n'
 
 export default function AboutPage() {
   const { t } = useLanguage()
+
   return (
     <main className="min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">{t('about')}</h1>
-        <p className="mt-4 text-muted">{t('aboutIntro')}</p>
-        <div className="mt-8 space-y-8">
-          <section>
-            <h2 className="font-heading text-2xl font-semibold text-text">
+      <section className="mx-auto max-w-5xl px-4 py-24">
+        <h1 className="font-heading text-4xl font-semibold text-text">{t('about')}</h1>
+        <p className="mt-6 text-lg text-muted">{t('aboutIntro')}</p>
+        <div className="mt-8">
+          <Link
+            href="/contact"
+            className="inline-block rounded bg-mint px-6 py-3 font-medium text-bg shadow-soft"
+          >
+            {t('letsTalk')}
+          </Link>
+        </div>
+      </section>
+
+      <section className="bg-surface py-24">
+        <div className="mx-auto grid max-w-5xl gap-12 px-4 md:grid-cols-2">
+          <div className="text-center">
+            <FiTarget className="mx-auto h-12 w-12 text-mint" aria-hidden="true" />
+            <h2 className="mt-4 font-heading text-2xl font-semibold text-text">
               {t('missionHeading')}
             </h2>
-            <p className="mt-2 text-muted">{t('missionBody')}</p>
-          </section>
-          <section>
-            <h2 className="font-heading text-2xl font-semibold text-text">
+            <p className="mt-2 text-sm text-muted">{t('missionBody')}</p>
+          </div>
+          <div className="text-center">
+            <FiHeart className="mx-auto h-12 w-12 text-mint" aria-hidden="true" />
+            <h2 className="mt-4 font-heading text-2xl font-semibold text-text">
               {t('valuesHeading')}
             </h2>
-            <p className="mt-2 text-muted">{t('valuesBody')}</p>
-          </section>
+            <p className="mt-2 text-sm text-muted">{t('valuesBody')}</p>
+          </div>
         </div>
-      </div>
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Redesign About page with hero section and contact CTA
- Showcase mission and values in a feature grid with icons for a consistent service-style look

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0bb360b9083269c0a6d399c85df07