### PR TITLE
feat: add blog post api and dynamic pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,36 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Publishing blog posts
+
+Blog posts can be managed through the `/api/posts` endpoints. To publish a new article, send a `POST` request with the post data:
+
+```bash
+curl -X POST http://localhost:3000/api/posts \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "slug": "my-first-post",
+    "title": "My First Post",
+    "excerpt": "Short summary shown on the blog list",
+    "body_md": "# Hello world\nThis is my first post!",
+    "image_url": "https://your-project.supabase.co/storage/v1/object/public/blog-images/hello.png"
+  }'
+```
+
+### Uploading images
+
+1. Create a `blog-images` bucket in the Supabase Storage dashboard.
+2. Upload your image to the bucket, e.g. using the Supabase JavaScript client:
+
+```ts
+const file = /* File or Blob */
+const { data, error } = await supabase.storage
+  .from('blog-images')
+  .upload('hello.png', file)
+const {
+  data: { publicUrl }
+} = supabase.storage.from('blog-images').getPublicUrl('hello.png')
+```
+
+3. Use the `publicUrl` as the `image_url` field when creating the post. The image will appear above the article content on its dedicated page.

--- a/src/app/api/posts/[slug]/route.ts
+++ b/src/app/api/posts/[slug]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase'
+
+// GET /api/posts/[slug] - return a single post by slug
+export async function GET(
+  _req: Request,
+  { params }: { params: { slug: string } }
+) {
+  const supabase = createSupabaseServerClient()
+  const { data, error } = await supabase
+    .from('posts')
+    .select('*')
+    .eq('slug', params.slug)
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 404 })
+  }
+
+  return NextResponse.json(data)
+}

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase'
+
+// GET /api/posts - return all posts
+export async function GET() {
+  const supabase = createSupabaseServerClient()
+  const { data, error } = await supabase.from('posts').select('*').order('created_at', { ascending: false })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+// POST /api/posts - create a new post
+export async function POST(req: Request) {
+  const supabase = createSupabaseServerClient()
+  const body = await req.json()
+  const { data, error } = await supabase.from('posts').insert(body).select().single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data, { status: 201 })
+}

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -1,11 +1,33 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { posts } from '@/data/posts'
 import { useLanguage } from '@/lib/i18n'
+
+type Post = {
+  slug: string
+  title: string
+  excerpt: string
+}
 
 export default function BlogClient() {
   const { t } = useLanguage()
+  const [posts, setPosts] = useState<Post[]>([])
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/posts')
+        if (res.ok) {
+          setPosts(await res.json())
+        }
+      } catch {
+        // ignore errors for now
+      }
+    }
+    load()
+  }, [])
+
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Image from 'next/image'
+
+interface Params {
+  slug: string
+}
+
+export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
+  const { slug } = await params
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
+  if (!res.ok) {
+    return { title: 'Post not found' }
+  }
+  const post = await res.json()
+  return { title: `${post.title} | AnalytiX`, description: post.excerpt }
+}
+
+export default async function BlogPostPage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
+  if (!res.ok) notFound()
+  const post = await res.json()
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-16">
+      <h1 className="font-heading text-3xl font-semibold text-text">{post.title}</h1>
+      <p className="mt-2 text-muted">{post.excerpt}</p>
+      {post.image_url && (
+        <div className="relative mt-6 aspect-[16/9] w-full overflow-hidden rounded-md">
+          <Image
+            src={post.image_url}
+            alt={post.title}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 768px"
+          />
+        </div>
+      )}
+      <article className="mt-8 whitespace-pre-wrap text-text">{post.body_md}</article>
+    </main>
+  )
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,9 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import supabaseConfig from '../../supabase.local.json'
 
+/**
+ * Create a Supabase client for use in the browser. Uses the public anon key.
+ */
 export function createSupabaseBrowserClient(): SupabaseClient {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? supabaseConfig.SUPABASE_URL
   const supabaseAnonKey =
@@ -12,3 +15,20 @@ export function createSupabaseBrowserClient(): SupabaseClient {
 
   return createClient(supabaseUrl, supabaseAnonKey)
 }
+
+/**
+ * Create a Supabase client for server-side usage. This uses the service role
+ * key which has elevated privileges and should only run on the server.
+ */
+export function createSupabaseServerClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? supabaseConfig.SUPABASE_URL
+  const supabaseServiceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? supabaseConfig.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error('Missing Supabase environment variables')
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey)
+}
+


### PR DESCRIPTION
## Summary
- add Supabase server client helper
- expose blog post CRUD API endpoints
- fetch blog posts from API and render dynamic article pages
- document how to publish posts and upload images
- display optional post images on article pages

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0be2911bc832683ec120215a019cf