### PR TITLE
feat: add user avatar menu

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'images.unsplash.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
     ],
   },
   async rewrites() {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import type { Metadata } from 'next'
+import { useLanguage } from '@/lib/i18n'
+
+export const metadata: Metadata = {
+  title: 'Settings | AnalytiX',
+  description: 'User settings',
+}
+
+export default function SettingsPage() {
+  const { t } = useLanguage()
+  return (
+    <main className="min-h-screen bg-bg p-4 text-text">
+      <h1 className="text-2xl font-semibold">{t('settings')}</h1>
+      <p className="mt-4 text-sm text-text/80">{t('comingSoon')}</p>
+    </main>
+  )
+}

--- a/src/images/avatar-placeholder.svg
+++ b/src/images/avatar-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <circle cx="20" cy="20" r="20" fill="#E5E7EB"/>
+  <path fill="#9CA3AF" d="M20 21a6 6 0 1 0 0-12 6 6 0 0 0 0 12Zm0 2c-7.333 0-14 3.667-14 8v3h28v-3c0-4.333-6.667-8-14-8Z"/>
+</svg>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -128,6 +128,8 @@ const translations: Record<Language, Record<string, string>> = {
     bookmarks: 'Bookmarks',
     add: 'Add',
     noBookmarksYet: 'No bookmarks yet.',
+    settings: 'Settings',
+    signOut: 'Sign Out',
   },
   es: {
     about: 'Acerca de',
@@ -257,6 +259,8 @@ const translations: Record<Language, Record<string, string>> = {
     bookmarks: 'Marcadores',
     add: 'Agregar',
     noBookmarksYet: 'Aún no hay marcadores.',
+    settings: 'Configuración',
+    signOut: 'Cerrar sesión',
   },
 }
 


### PR DESCRIPTION
## Summary
- show logged-in user avatar with dropdown menu
- add settings page and translations
- allow remote avatars from GitHub and Google

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0c63ba3e4832698f81c8eae7a013b