### PR TITLE
Remove client_id from GitHub OAuth sign-in

### DIFF
--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -26,15 +26,10 @@ export default function LoginClient() {
 
   const handleProviderLogin = (provider: 'google' | 'github') => async () => {
     const supabase = createSupabaseBrowserClient()
-    const clientId =
-      provider === 'github'
-        ? supabaseConfig.GITHUB_CLIENT_ID
-        : supabaseConfig.GOOGLE_CLIENT_ID
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: supabaseConfig.SUPABASE_CALLBACK_URL,
-        queryParams: { client_id: clientId },
       },
     })
     if (error) setMessage(error.message)


### PR DESCRIPTION
## Summary
- avoid provider profile fetch failures by letting Supabase handle OAuth client ids

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0cd5720948326bddba86daa9aebd1