### PR TITLE
Add GitHub scope when using custom OAuth client

### DIFF
--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -30,11 +30,13 @@ export default function LoginClient() {
       provider === 'github'
         ? supabaseConfig.GITHUB_CLIENT_ID
         : supabaseConfig.GOOGLE_CLIENT_ID
+    const scopes = provider === 'github' ? 'read:user user:email' : undefined
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: supabaseConfig.SUPABASE_CALLBACK_URL,
         queryParams: { client_id: clientId },
+        ...(scopes ? { scopes } : {}),
       },
     })
     if (error) setMessage(error.message)


### PR DESCRIPTION
## Summary
- keep provider client ID override for OAuth
- request `user:email` scope for GitHub to prevent profile fetch failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0cd5720948326bddba86daa9aebd1