### PR TITLE
feat(navbar): enhance user menu

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,6 +9,7 @@ import type { User } from '@supabase/supabase-js'
 import logoDesktop from '@/images/logos/desktop/logo_navbar.png'
 import logoMobile from '@/images/logos/mobile/logo_navbar.png'
 import avatarPlaceholder from '@/images/avatar-placeholder.svg'
+import { FiMail, FiSettings, FiLogOut } from 'react-icons/fi'
 
 const links = [
   { href: '/about', label: 'about' },
@@ -285,6 +286,12 @@ export default function Navbar() {
           >
             {lang === 'en' ? 'ES' : 'EN'}
           </button>
+          <Link
+            href="/contact"
+            className="hidden rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90 sm:inline"
+          >
+            {t('letsTalk')}
+          </Link>
           {user ? (
             <div
               className="relative"
@@ -302,18 +309,24 @@ export default function Navbar() {
                 <div
                   onMouseEnter={openUserMenu}
                   onMouseLeave={closeUserMenu}
-                  className="absolute right-0 mt-2 w-40 rounded-md border border-stroke/60 bg-surface p-2 shadow-soft"
+                  className="absolute right-0 mt-2 w-56 rounded-md border border-stroke/60 bg-surface p-2 shadow-soft"
                 >
+                  <div className="flex items-center gap-2 rounded px-4 py-2 text-sm text-text">
+                    <FiMail className="h-4 w-4" />
+                    {user.email}
+                  </div>
                   <Link
                     href="/settings"
-                    className="block rounded px-4 py-2 text-sm text-text/80 hover:bg-mint/10 hover:text-text"
+                    className="flex items-center gap-2 rounded px-4 py-2 text-sm text-text/80 hover:bg-mint/10 hover:text-text"
                   >
-                    {t('settings')}
+                    <FiSettings className="h-4 w-4" />
+                    {t('accountPreferences')}
                   </Link>
                   <button
                     onClick={handleSignOut}
-                    className="block w-full text-left rounded px-4 py-2 text-sm text-text/80 hover:bg-mint/10 hover:text-text"
+                    className="flex w-full items-center gap-2 rounded px-4 py-2 text-left text-sm text-text/80 hover:bg-mint/10 hover:text-text"
                   >
+                    <FiLogOut className="h-4 w-4" />
                     {t('signOut')}
                   </button>
                 </div>
@@ -327,12 +340,6 @@ export default function Navbar() {
               {t('login')}
             </Link>
           )}
-          <Link
-            href="/contact"
-            className="hidden rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft hover:opacity-90 sm:inline"
-          >
-            {t('letsTalk')}
-          </Link>
         </div>
       </nav>
     </header>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -129,7 +129,8 @@ const translations: Record<Language, Record<string, string>> = {
     add: 'Add',
     noBookmarksYet: 'No bookmarks yet.',
     settings: 'Settings',
-    signOut: 'Sign Out',
+    signOut: 'Logout',
+    accountPreferences: 'Account Preferences',
   },
   es: {
     about: 'Acerca de',
@@ -261,6 +262,7 @@ const translations: Record<Language, Record<string, string>> = {
     noBookmarksYet: 'Aún no hay marcadores.',
     settings: 'Configuración',
     signOut: 'Cerrar sesión',
+    accountPreferences: 'Preferencias de cuenta',
   },
 }
 


### PR DESCRIPTION
## Summary
- show logged-in email at top of user menu
- rename menu items and add icons
- reposition user avatar to rightmost of navbar

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0d6b04b1083269aede6c74dd56f11