### PR TITLE
Use /posts API for blog pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 Posts can be created from the `/blog/new` page which provides fields for the title, excerpt, Markdown body and an optional image upload. The image is stored in the Supabase `posts` storage bucket under a folder for the current user's UUID and automatically linked to the post.
 
-You can also manage posts through the `/api/posts` endpoints. To publish a new article programmatically, send a `POST` request with the post data:
+You can also manage posts through the `/posts` endpoints. To publish a new article programmatically, send a `POST` request with the post data:
 
 ```bash
-curl -X POST http://localhost:3000/api/posts \
+curl -X POST http://localhost:3000/posts \
   -H 'Content-Type: application/json' \
   -d '{
     "slug": "my-first-post",

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -17,7 +17,7 @@ export default function BlogClient() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/api/posts')
+        const res = await fetch('/posts')
         if (res.ok) {
           setPosts(await res.json())
         }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,7 +11,7 @@ interface Params {
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
   const { slug } = await params
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
+  const res = await fetch(`${baseUrl}/posts/${slug}`, { cache: 'no-store' })
   if (!res.ok) {
     return { title: 'Post not found' }
   }
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
 export default async function BlogPostPage({ params }: { params: Promise<Params> }) {
   const { slug } = await params
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
+  const res = await fetch(`${baseUrl}/posts/${slug}`, { cache: 'no-store' })
   if (!res.ok) notFound()
   const post = await res.json()
   return (

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -41,7 +41,7 @@ export default function NewPostPage() {
         .trim()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '')
-      const res = await fetch('/api/posts', {
+      const res = await fetch('/posts', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slug, title, excerpt, body_md: body, image_url }),


### PR DESCRIPTION
## Summary
- Fetch blog posts from the `/posts` endpoint instead of `/api/posts`
- Update post detail and creation pages to use `/posts`
- Document `/posts` API usage in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a0f8f8c9488326b5d476c687f063b1