### PR TITLE
feat: redesign contact page

### DIFF
--- a/src/app/contact/ContactClient.tsx
+++ b/src/app/contact/ContactClient.tsx
@@ -1,20 +1,70 @@
 'use client'
 
+import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n'
 
 export default function ContactClient() {
   const { t } = useLanguage()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [reason, setReason] = useState('info')
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const to = reason === 'support' ? 'support@analytixcg.com' : 'info@analytixcg.com'
+    const subject =
+      reason === 'support'
+        ? `Support request from ${name}`
+        : `Contact from ${name}`
+    const body = `${message}\n\nFrom: ${name}${email ? ` <${email}>` : ''}`
+    window.location.href = `mailto:${to}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+  }
+
   return (
     <main className="min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 py-16">
-        <h1 className="font-heading text-3xl font-semibold text-text">{t('contact')}</h1>
-        <p className="mt-4 text-muted">
-          {t('reachUsAt')}{' '}
-          <a href="mailto:hello@example.com" className="text-mint">
-            hello@example.com
-          </a>
-        </p>
-      </div>
+      <section className="mx-auto max-w-5xl px-4 py-24">
+        <h1 className="font-heading text-4xl font-semibold text-text">{t('contact')}</h1>
+        <p className="mt-6 text-lg text-muted">{t('contactIntro')}</p>
+        <form onSubmit={handleSubmit} className="mt-8 grid gap-4 md:max-w-lg">
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder={t('namePlaceholder')}
+            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder={t('emailPlaceholder')}
+            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
+          />
+          <select
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text focus:border-mint focus:outline-none"
+          >
+            <option value="info">{t('general')}</option>
+            <option value="support">{t('support')}</option>
+          </select>
+          <textarea
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            placeholder={t('messagePlaceholder')}
+            rows={5}
+            className="w-full rounded-md border border-stroke/60 bg-bg px-3 py-2 text-sm text-text placeholder:text-muted focus:border-mint focus:outline-none"
+          />
+          <button
+            type="submit"
+            className="rounded-xl2 bg-mint px-4 py-2 text-sm font-medium text-black shadow-soft transition hover:opacity-90"
+          >
+            {t('sendMessage')}
+          </button>
+        </form>
+      </section>
     </main>
   )
 }
+

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -32,6 +32,15 @@ const translations: Record<Language, Record<string, string>> = {
     valuesBody:
       'We champion innovation, creativity, dedication, and expertise. Energetic and modern, developer-focused and committed, Code Groove is the trusted crosspoint where technology meets imagination and data meets business.',
     reachUsAt: 'Reach us at',
+    contactIntro: 'Let us know how we can help',
+    name: 'Name',
+    namePlaceholder: 'Your name',
+    reason: 'Reason',
+    message: 'Message',
+    messagePlaceholder: 'Your message',
+    general: 'General inquiry',
+    support: 'Support',
+    sendMessage: 'Send message',
     moreInfoHeading: 'Why AnalytiX?',
     moreInfoBody:
       'From data foundations to AI, we guide you from idea to production with a battle-tested team.',
@@ -159,6 +168,15 @@ const translations: Record<Language, Record<string, string>> = {
     valuesBody:
       'Impulsamos la innovación, la creatividad, la dedicación y la experiencia. Enérgico y enfocado en los desarrolladores, Code Groove es el punto de cruce confiable donde la tecnología se encuentra con la imaginación y los datos con el negocio.',
     reachUsAt: 'Contáctanos en',
+    contactIntro: 'Cuéntanos cómo podemos ayudarte',
+    name: 'Nombre',
+    namePlaceholder: 'Tu nombre',
+    reason: 'Motivo',
+    message: 'Mensaje',
+    messagePlaceholder: 'Tu mensaje',
+    general: 'Consulta general',
+    support: 'Soporte',
+    sendMessage: 'Enviar mensaje',
     moreInfoHeading: '¿Por qué AnalytiX?',
     moreInfoBody:
       'Desde bases de datos hasta IA, te ayudamos a llevar las ideas a producción con un equipo experimentado.',


### PR DESCRIPTION
## Summary
- redesign contact page with inquiry form
- route support and general messages to appropriate emails
- add translations for new contact form strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1009f89b883268b9526ed0749749b