### PR TITLE
feat: enrich MoreInfo section on homepage

### DIFF
--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -1,14 +1,48 @@
 "use client"
 
 import { useLanguage } from '@/lib/i18n'
+import {
+  FiDatabase,
+  FiCpu,
+  FiSmartphone,
+  FiSettings,
+  FiCloud,
+  FiMap,
+} from 'react-icons/fi'
 
 export default function MoreInfo() {
   const { t } = useLanguage()
+
+  const offerings = [
+    { Icon: FiDatabase, titleKey: 'dataAnalytics', descKey: 'dataAnalyticsCard' },
+    { Icon: FiCpu, titleKey: 'aiAutomation', descKey: 'aiAutomationCard' },
+    { Icon: FiSmartphone, titleKey: 'appsApis', descKey: 'appsApisCard' },
+    { Icon: FiSettings, titleKey: 'automationQa', descKey: 'automationQaCard' },
+    { Icon: FiCloud, titleKey: 'cloudDevops', descKey: 'cloudDevopsCard' },
+    { Icon: FiMap, titleKey: 'itConsulting', descKey: 'itConsultingCard' },
+  ]
+
   return (
     <section className="bg-bg py-14">
       <div className="mx-auto max-w-6xl px-4">
         <h2 className="mb-4 font-heading text-2xl font-semibold text-text">{t('moreInfoHeading')}</h2>
-        <p className="text-muted">{t('moreInfoBody')}</p>
+        <p className="max-w-3xl text-muted">{t('moreInfoBody')}</p>
+        <ul className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {offerings.map(({ Icon, titleKey, descKey }) => (
+            <li
+              key={titleKey}
+              className="flex items-start gap-3 rounded-xl2 border border-stroke/70 bg-surface p-4 shadow-soft"
+            >
+              <Icon className="mt-1 shrink-0 text-mint" />
+              <div>
+                <h3 className="font-heading text-base font-semibold text-text">
+                  {t(titleKey)}
+                </h3>
+                <p className="text-sm text-muted">{t(descKey)}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   )

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -45,7 +45,7 @@ const translations: Record<Language, Record<string, string>> = {
     messageError: 'Failed to send message. Please try again.',
     moreInfoHeading: 'Why AnalytiX?',
     moreInfoBody:
-      'From data foundations to AI, we guide you from idea to production with a battle-tested team.',
+      'From data foundations to AI, we take ideas to production. Explore our core services below and see how our battle-tested team helps you build, automate, and scale.',
     latestPosts: 'Latest posts',
     readMore: 'Read more →',
     whereData: 'Where Data',
@@ -183,7 +183,7 @@ const translations: Record<Language, Record<string, string>> = {
     messageError: 'No se pudo enviar el mensaje. Inténtalo de nuevo.',
     moreInfoHeading: '¿Por qué AnalytiX?',
     moreInfoBody:
-      'Desde bases de datos hasta IA, te ayudamos a llevar las ideas a producción con un equipo experimentado.',
+      'Desde bases de datos hasta IA, llevamos tus ideas a producción. Explora nuestros servicios y descubre cómo nuestro equipo experimentado te ayuda a construir, automatizar y escalar.',
     latestPosts: 'Últimas publicaciones',
     readMore: 'Leer más →',
     whereData: 'Where Data',


### PR DESCRIPTION
## Summary
- expand homepage MoreInfo component with card-style service overview and icons
- elaborate translations for Why AnalytiX section in English and Spanish

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a34540b2ac83269f899a743e5b985d