### PR TITLE
Refine homepage MoreInfo and use Supabase credentials for contact API

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,12 +1,31 @@
 import { NextResponse } from 'next/server'
 import nodemailer from 'nodemailer'
+import fs from 'node:fs'
+import path from 'node:path'
 
 export const runtime = 'nodejs' // ensure Node runtime for nodemailer
 
+let localEnv: Record<string, unknown> | null = null
+
+function loadLocalEnv() {
+  if (localEnv) return localEnv
+  try {
+    const file = fs.readFileSync(
+      path.join(process.cwd(), 'supabase.local.json'),
+      'utf-8',
+    )
+    localEnv = JSON.parse(file)
+  } catch {
+    localEnv = {}
+  }
+  return localEnv
+}
+
 function env(name: string) {
-  const v = process.env[name]
-  if (!v) throw new Error(`Missing env: ${name}`)
-  return v
+  const v = process.env[name] ?? (loadLocalEnv() as Record<string, unknown>)[name]
+  if (v === undefined || v === null)
+    throw new Error(`Missing env: ${name}`)
+  return String(v)
 }
 
 export async function POST(req: Request) {
@@ -18,14 +37,14 @@ export async function POST(req: Request) {
 
     const transporter = nodemailer.createTransport({
       host: env('SMTP_HOST'),
-      port: Number(process.env.SMTP_PORT ?? 587),
-      secure: process.env.SMTP_SECURE === 'true', // true only for 465
+      port: Number(env('SMTP_PORT') || 587),
+      secure: env('SMTP_SECURE') === 'true', // true only for 465
       auth: { user: env('SMTP_USER'), pass: env('SMTP_PASS') },
       requireTLS: true, // Office365 on 587 uses STARTTLS
     })
 
     await transporter.sendMail({
-      from: `${env('EMAIL_FROM_NAME')} <${env('EMAIL_FROM_ADDRESS')}>`,
+      from: env('SMTP_FROM'),
       to,
       subject:
         reason === 'support'

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -1,30 +1,11 @@
 "use client"
 
 import { useLanguage } from '@/lib/i18n'
-import {
-  FiDatabase,
-  FiCpu,
-  FiSmartphone,
-  FiSettings,
-  FiCloud,
-  FiMap,
-  FiActivity,
-  FiZap,
-  FiFeather,
-  FiDollarSign,
-} from 'react-icons/fi'
+import Link from 'next/link'
+import { FiActivity, FiZap, FiFeather, FiDollarSign } from 'react-icons/fi'
 
 export default function MoreInfo() {
   const { t } = useLanguage()
-
-  const offerings = [
-    { Icon: FiDatabase, titleKey: 'dataAnalytics', descKey: 'dataAnalyticsCard' },
-    { Icon: FiCpu, titleKey: 'aiAutomation', descKey: 'aiAutomationCard' },
-    { Icon: FiSmartphone, titleKey: 'appsApis', descKey: 'appsApisCard' },
-    { Icon: FiSettings, titleKey: 'automationQa', descKey: 'automationQaCard' },
-    { Icon: FiCloud, titleKey: 'cloudDevops', descKey: 'cloudDevopsCard' },
-    { Icon: FiMap, titleKey: 'itConsulting', descKey: 'itConsultingCard' },
-  ]
 
   const industries = [
     { Icon: FiActivity, titleKey: 'healthcareIndustry', descKey: 'healthcareIndustryDesc' },
@@ -38,22 +19,6 @@ export default function MoreInfo() {
       <div className="mx-auto max-w-6xl px-4">
         <h2 className="mb-4 font-heading text-2xl font-semibold text-text">{t('moreInfoHeading')}</h2>
         <p className="max-w-3xl text-muted">{t('moreInfoBody')}</p>
-        <ul className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {offerings.map(({ Icon, titleKey, descKey }) => (
-            <li
-              key={titleKey}
-              className="flex items-start gap-3 rounded-xl2 border border-stroke/70 bg-surface p-4 shadow-soft"
-            >
-              <Icon className="mt-1 shrink-0 text-mint" />
-              <div>
-                <h3 className="font-heading text-base font-semibold text-text">
-                  {t(titleKey)}
-                </h3>
-                <p className="text-sm text-muted">{t(descKey)}</p>
-              </div>
-            </li>
-          ))}
-        </ul>
         <h3 className="mt-16 mb-4 font-heading text-xl font-semibold text-text">
           {t('industriesHeading')}
         </h3>
@@ -73,6 +38,14 @@ export default function MoreInfo() {
             </li>
           ))}
         </ul>
+        <div className="mt-10 text-center">
+          <Link
+            href="/contact"
+            className="font-heading font-semibold text-mint hover:underline"
+          >
+            {t('contact')}
+          </Link>
+        </div>
       </div>
     </section>
   )

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -45,7 +45,7 @@ const translations: Record<Language, Record<string, string>> = {
     messageError: 'Failed to send message. Please try again.',
     moreInfoHeading: 'Why AnalytiX?',
     moreInfoBody:
-      'From data foundations to scalable apps, we take ideas to production. Explore our core services and see how they power industries like healthcare, energy, agriculture, and finance.',
+      'From data foundations to scalable apps, we take ideas to production. See how our expertise powers industries like healthcare, energy, agriculture, and finance.',
     industriesHeading: 'Industries we serve',
     healthcareIndustry: 'Healthcare',
     healthcareIndustryDesc:
@@ -196,7 +196,7 @@ const translations: Record<Language, Record<string, string>> = {
     messageError: 'No se pudo enviar el mensaje. Inténtalo de nuevo.',
     moreInfoHeading: '¿Por qué AnalytiX?',
     moreInfoBody:
-      'Desde bases de datos hasta apps escalables, llevamos tus ideas a producción. Explora nuestros servicios y descubre cómo impulsan industrias como salud, energía, agro y finanzas.',
+      'Desde bases de datos hasta apps escalables, llevamos tus ideas a producción. Descubre cómo nuestra experiencia impulsa industrias como salud, energía, agro y finanzas.',
     industriesHeading: 'Industrias que atendemos',
     healthcareIndustry: 'Salud',
     healthcareIndustryDesc:


### PR DESCRIPTION
## Summary
- show only industry cards in homepage MoreInfo section and add contact link
- load SMTP settings from `supabase.local.json` and use `SMTP_FROM` when sending mail
- tweak copy around "Why AnalytiX?" in both English and Spanish

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a351db5bbc83269e6a4cbdb935a6f5