### PR TITLE
Use icons instead of images on services page

### DIFF
--- a/src/app/services/ServicesClient.tsx
+++ b/src/app/services/ServicesClient.tsx
@@ -2,8 +2,9 @@
 
 import { services } from '@/data/services'
 import { useLanguage } from '@/lib/i18n'
-import Image from 'next/image'
 import Link from 'next/link'
+import * as Icons from 'react-icons/fi'
+import type { IconType } from 'react-icons'
 
 export default function ServicesClient() {
   const { t } = useLanguage()
@@ -20,16 +21,15 @@ export default function ServicesClient() {
             href={`/services/${s.slug}`}
             className="group overflow-hidden rounded-xl2 border border-stroke/70 bg-surface shadow-soft transition hover:border-mint/60"
           >
-            {s.imageSrc && (
-              <Image
-                src={s.imageSrc}
-                alt={s.imageAlt ?? ''}
-                width={800}
-                height={400}
-                className="h-48 w-full object-cover"
-              />
-            )}
             <div className="p-6">
+              <div className="mb-4 flex gap-4">
+                {(s.cardIcons ?? s.features.slice(0, 3).map(f => f.icon)).map(iconName => {
+                  const Icon = (Icons as Record<string, IconType>)[iconName]
+                  return Icon ? (
+                    <Icon key={iconName} aria-hidden="true" className="h-10 w-10 text-mint" />
+                  ) : null
+                })}
+              </div>
               <h2 className="font-heading text-xl font-semibold text-text group-hover:text-mint">
                 {t(s.titleKey)}
               </h2>

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -14,6 +14,7 @@ export type Service = {
   features: ReadonlyArray<Feature>
   imageSrc?: string | StaticImageData
   imageAlt?: string
+  cardIcons?: ReadonlyArray<string>
 }
 
 export const services: ReadonlyArray<Service> = [
@@ -23,6 +24,7 @@ export const services: ReadonlyArray<Service> = [
     descKey: 'dataAnalyticsDesc',
     cardBlurbKey: 'dataAnalyticsCard',
     imageAlt: 'Data & Analytics service illustration',
+    cardIcons: ['FiDatabase', 'FiPieChart', 'FiBarChart'],
     features: [
       {
         icon: 'FiDatabase',
@@ -63,6 +65,7 @@ export const services: ReadonlyArray<Service> = [
     cardBlurbKey: 'aiAutomationCard',
     imageSrc:
       'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=800&q=80',
+    cardIcons: ['FiCpu', 'FiZap', 'FiActivity'],
     features: [
       {
         icon: 'FiCpu',
@@ -88,6 +91,7 @@ export const services: ReadonlyArray<Service> = [
     cardBlurbKey: 'appsApisCard',
     imageSrc:
       'https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=800&q=80',
+    cardIcons: ['FiSmartphone', 'FiCode', 'FiActivity'],
     features: [
       {
         icon: 'FiSmartphone',
@@ -113,6 +117,7 @@ export const services: ReadonlyArray<Service> = [
     cardBlurbKey: 'automationQaCard',
     imageSrc:
       'https://images.unsplash.com/photo-1581090700227-4f9a6d3a3c0a?auto=format&fit=crop&w=800&q=80',
+    cardIcons: ['FiSettings', 'FiCheckSquare', 'FiShield'],
     features: [
       {
         icon: 'FiSettings',
@@ -138,6 +143,7 @@ export const services: ReadonlyArray<Service> = [
     cardBlurbKey: 'cloudDevopsCard',
     imageSrc:
       'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=80',
+    cardIcons: ['FiCloud', 'FiRefreshCw', 'FiLock'],
     features: [
       {
         icon: 'FiCloud',
@@ -163,6 +169,7 @@ export const services: ReadonlyArray<Service> = [
     cardBlurbKey: 'itConsultingCard',
     imageSrc:
       'https://images.unsplash.com/photo-1551836022-02eeb4e36dd0?auto=format&fit=crop&w=800&q=80',
+    cardIcons: ['FiMap', 'FiLayers', 'FiCompass'],
     features: [
       {
         icon: 'FiMap',


### PR DESCRIPTION
## Summary
- show up to three icons for each offering on the services page
- define dedicated icon sets for every service in data file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a35b068670832681dc506ed1d0c5b6