### PR TITLE
Add profile CRUD API and ensure user profiles on auth

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase'
+
+// GET /api/profiles - return the current user's profile
+export async function GET() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { data, error } = await supabase
+    .from('profiles', { schema: 'api' })
+    .select('*')
+    .eq('id', user.id)
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+// POST /api/profiles - create or update the current user's profile
+export async function POST(req: Request) {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const body = await req.json()
+  const { data, error } = await supabase
+    .from('profiles', { schema: 'api' })
+    .upsert({ id: user.id, ...body }, { onConflict: 'id' })
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data, { status: 201 })
+}
+
+// PUT /api/profiles - update fields on the current user's profile
+export async function PUT(req: Request) {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const body = await req.json()
+  const { data, error } = await supabase
+    .from('profiles', { schema: 'api' })
+    .update(body)
+    .eq('id', user.id)
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+// DELETE /api/profiles - remove the current user's profile
+export async function DELETE() {
+  const supabase = createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { error } = await supabase
+    .from('profiles', { schema: 'api' })
+    .delete()
+    .eq('id', user.id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}

--- a/src/app/signup/SignupClient.tsx
+++ b/src/app/signup/SignupClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import type { User } from '@supabase/supabase-js'
 import Image from 'next/image'
 import Link from 'next/link'
 import { FaGithub, FaGoogle, FaTimes } from 'react-icons/fa'
@@ -12,16 +13,48 @@ export default function SignupClient() {
   const [email, setEmail] = useState('')
   const [message, setMessage] = useState('')
   const { t } = useLanguage()
+  const supabase = useMemo(() => createSupabaseBrowserClient(), [])
+
+  const ensureProfile = useCallback(
+    async (user: User) => {
+      const fullName =
+        user.user_metadata?.full_name ||
+        user.user_metadata?.name ||
+        user.user_metadata?.user_name ||
+        user.email
+      const avatarUrl = user.user_metadata?.avatar_url || user.user_metadata?.picture || null
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      await fetch('/api/profiles', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token ?? ''}`,
+        },
+        body: JSON.stringify({ full_name: fullName, avatar_url: avatarUrl }),
+      })
+    },
+    [supabase]
+  )
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      const u = session?.user
+      if (u) ensureProfile(u)
+    })
+    return () => subscription.unsubscribe()
+  }, [supabase, ensureProfile])
 
   const handleEmailSignup = async (e: React.FormEvent) => {
     e.preventDefault()
-    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOtp({ email })
     setMessage(error ? error.message : t('checkEmailForLink'))
   }
 
   const handleProviderSignup = (provider: 'google' | 'github') => async () => {
-    const supabase = createSupabaseBrowserClient()
     const { error } = await supabase.auth.signInWithOAuth({ provider })
     if (error) setMessage(error.message)
   }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -150,9 +150,17 @@ export default function Navbar() {
         user.user_metadata?.user_name ||
         user.email
       const avatarUrl = user.user_metadata?.avatar_url || user.user_metadata?.picture || null
-      await supabase
-        .from('profiles', { schema: 'api' })
-        .upsert({ id: user.id, full_name: fullName, avatar_url: avatarUrl }, { onConflict: 'id' })
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      await fetch('/api/profiles', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token ?? ''}`,
+        },
+        body: JSON.stringify({ full_name: fullName, avatar_url: avatarUrl }),
+      })
     },
     [supabase]
   )


### PR DESCRIPTION
## Summary
- add `/api/profiles` route with GET/POST/PUT/DELETE handlers using Supabase
- call the new route after email or OAuth sign in to upsert user profile info
- update navbar to persist profile data through the new API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38a95590c83269f69c74363a1a6d7