### PR TITLE
fix: authenticate profile API

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,12 +1,23 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase'
 
-// GET /api/profiles - return the current user's profile
-export async function GET() {
+// Extract the authenticated user from the request Authorization header.
+async function getUser(req: Request) {
   const supabase = createSupabaseServerClient()
+  const authHeader = req.headers.get('Authorization')
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined
+  if (!token) return { supabase, user: null }
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser(token)
+  return { supabase, user }
+}
+
+// GET /api/profiles - return the current user's profile
+export async function GET(req: Request) {
+  const { supabase, user } = await getUser(req)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -23,10 +34,7 @@ export async function GET() {
 
 // POST /api/profiles - create or update the current user's profile
 export async function POST(req: Request) {
-  const supabase = createSupabaseServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { supabase, user } = await getUser(req)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -44,10 +52,7 @@ export async function POST(req: Request) {
 
 // PUT /api/profiles - update fields on the current user's profile
 export async function PUT(req: Request) {
-  const supabase = createSupabaseServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { supabase, user } = await getUser(req)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -65,11 +70,8 @@ export async function PUT(req: Request) {
 }
 
 // DELETE /api/profiles - remove the current user's profile
-export async function DELETE() {
-  const supabase = createSupabaseServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+export async function DELETE(req: Request) {
+  const { supabase, user } = await getUser(req)
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }


### PR DESCRIPTION
## Summary
- parse Authorization bearer tokens in profile API
- authenticate profile requests before accessing the database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3919e03b88326b29c1308481f030d