### PR TITLE
Centralize profile syncing across auth flows

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const { data, error } = await supabase
-    .from('api.profiles')
+    .from('profiles', { schema: 'api' })
     .select('*')
     .eq('id', user.id)
     .single()
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
   }
   const body = await req.json()
   const { data, error } = await supabase
-    .from('api.profiles')
+    .from('profiles', { schema: 'api' })
     .upsert({ id: user.id, ...body }, { onConflict: 'id' })
     .select()
     .single()
@@ -58,7 +58,7 @@ export async function PUT(req: Request) {
   }
   const body = await req.json()
   const { data, error } = await supabase
-    .from('api.profiles')
+    .from('profiles', { schema: 'api' })
     .update(body)
     .eq('id', user.id)
     .select()
@@ -76,7 +76,7 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const { error } = await supabase
-    .from('api.profiles')
+    .from('profiles', { schema: 'api' })
     .delete()
     .eq('id', user.id)
   if (error) {

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
-import type { User } from '@supabase/supabase-js'
+import { useState, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { FaGithub, FaGoogle, FaTimes } from 'react-icons/fa'
 import { useRouter } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n'
 import { createSupabaseBrowserClient } from '@/lib/supabase'
+import { ensureProfile } from '@/lib/profile'
 import logo from '@/images/logos/desktop/logo_login.png'
 
 export default function LoginClient() {
@@ -18,43 +18,20 @@ export default function LoginClient() {
   const { t } = useLanguage()
   const supabase = useMemo(() => createSupabaseBrowserClient(), [])
 
-  const ensureProfile = useCallback(
-    async (user: User) => {
-      const fullName =
-        user.user_metadata?.full_name ||
-        user.user_metadata?.name ||
-        user.user_metadata?.user_name ||
-        user.email
-      const avatarUrl = user.user_metadata?.avatar_url || user.user_metadata?.picture || null
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      await fetch('/api/profiles', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${session?.access_token ?? ''}`,
-        },
-        body: JSON.stringify({ full_name: fullName, avatar_url: avatarUrl }),
-      })
-    },
-    [supabase]
-  )
-
   useEffect(() => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
       const u = session?.user
-      if (u) ensureProfile(u)
+      if (u) ensureProfile(supabase, u)
     })
     return () => subscription.unsubscribe()
-  }, [supabase, ensureProfile])
+  }, [supabase])
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
     const { data, error } = await supabase.auth.signInWithPassword({ email, password })
-    if (!error && data.user) await ensureProfile(data.user)
+    if (!error && data.user) await ensureProfile(supabase, data.user)
     setMessage(error ? error.message : '')
   }
 

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js'
+
+/**
+ * Ensure a profile exists for the given user by syncing auth metadata to the
+ * `api.profiles` table.
+ */
+export async function ensureProfile(
+  supabase: SupabaseClient,
+  user: User
+): Promise<void> {
+  const fullName =
+    user.user_metadata?.full_name ||
+    user.user_metadata?.name ||
+    user.user_metadata?.user_name ||
+    user.email
+  const avatarUrl = user.user_metadata?.avatar_url || user.user_metadata?.picture || null
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  await fetch('/api/profiles', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session?.access_token ?? ''}`,
+    },
+    body: JSON.stringify({ full_name: fullName, avatar_url: avatarUrl }),
+  })
+}
+


### PR DESCRIPTION
## Summary
- add shared `ensureProfile` helper to sync `auth.users` data with `api.profiles`
- invoke profile sync after auth events in login, signup, and navbar components
- fix profiles API to target `api` schema so user records can be upserted without server errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39b59917c8326849b5a5affad48c7