### PR TITLE
refactor: split supabase clients

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -13,7 +13,11 @@ export async function GET() {
 
 // POST /api/posts - create a new post
 export async function POST(req: Request) {
-  const supabase = createSupabaseServerClient()
+  const authHeader = req.headers.get('Authorization')
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : undefined
+  const supabase = createSupabaseServerClient(token)
   const {
     data: { user },
   } = await supabase.auth.getUser()

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -3,15 +3,15 @@ import { createSupabaseServerClient } from '@/lib/supabase'
 
 // Extract the authenticated user from the request Authorization header.
 async function getUser(req: Request) {
-  const supabase = createSupabaseServerClient()
   const authHeader = req.headers.get('Authorization')
   const token = authHeader?.startsWith('Bearer ')
     ? authHeader.slice(7)
     : undefined
+  const supabase = createSupabaseServerClient(token)
   if (!token) return { supabase, user: null }
   const {
     data: { user },
-  } = await supabase.auth.getUser(token)
+  } = await supabase.auth.getUser()
   return { supabase, user }
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,11 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
-import supabaseConfig from '../../supabase.local.json'
 
 /**
  * Create a Supabase client for use in the browser. Uses the public anon key.
  */
 export function createSupabaseBrowserClient(): SupabaseClient {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? supabaseConfig.SUPABASE_URL
-  const supabaseAnonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? supabaseConfig.SUPABASE_ANON_KEY
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
   if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Missing Supabase environment variables')
@@ -17,18 +15,21 @@ export function createSupabaseBrowserClient(): SupabaseClient {
 }
 
 /**
- * Create a Supabase client for server-side usage. This uses the service role
- * key which has elevated privileges and should only run on the server.
+ * Create a Supabase client for server-side user requests. This uses the anon
+ * key and optionally attaches the user's access token to the request headers so
+ * that Row Level Security (RLS) policies apply per user.
  */
-export function createSupabaseServerClient(): SupabaseClient {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? supabaseConfig.SUPABASE_URL
-  const supabaseServiceKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? supabaseConfig.SUPABASE_SERVICE_ROLE_KEY
+export function createSupabaseServerClient(accessToken?: string): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-  if (!supabaseUrl || !supabaseServiceKey) {
+  if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Missing Supabase environment variables')
   }
 
-  return createClient(supabaseUrl, supabaseServiceKey)
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+    },
+  })
 }
-

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,0 +1,28 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function loadLocalEnv(): Record<string, string> {
+  try {
+    const file = fs.readFileSync(path.join(process.cwd(), 'supabase.local.json'), 'utf8')
+    return JSON.parse(file) as Record<string, string>
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Create a Supabase client with the service-role key. This should only be used
+ * for trusted server-side jobs and must never run in the browser.
+ */
+export function createSupabaseAdminClient(): SupabaseClient {
+  const localEnv = loadLocalEnv()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? localEnv['SUPABASE_URL']
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? localEnv['SUPABASE_SERVICE_ROLE_KEY']
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error('Missing Supabase environment variables')
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey)
+}


### PR DESCRIPTION
## Summary
- use anon key for server-side user client and pass JWT via headers
- add admin-only client that uses service role key on server
- update profile and posts API routes to require user tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3a88f2c6c83268adb62225e543ddd