### PR TITLE
fix: wait for session before syncing profile

### DIFF
--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -22,7 +22,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const { data, error } = await supabase
-    .from('api.profiles')
+    .schema('api')
+    .from('profiles')
     .select('*')
     .eq('id', user.id)
     .single()
@@ -40,7 +41,8 @@ export async function POST(req: Request) {
   }
   const body = await req.json()
   const { data, error } = await supabase
-    .from('api.profiles')
+    .schema('api')
+    .from('profiles')
     .upsert({ id: user.id, ...body }, { onConflict: 'id' })
     .select()
     .single()
@@ -58,7 +60,8 @@ export async function PUT(req: Request) {
   }
   const body = await req.json()
   const { data, error } = await supabase
-    .from('api.profiles')
+    .schema('api')
+    .from('profiles')
     .update(body)
     .eq('id', user.id)
     .select()
@@ -76,7 +79,8 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const { error } = await supabase
-    .from('api.profiles')
+    .schema('api')
+    .from('profiles')
     .delete()
     .eq('id', user.id)
   if (error) {

--- a/src/app/login/LoginClient.tsx
+++ b/src/app/login/LoginClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { FaGithub, FaGoogle, FaTimes } from 'react-icons/fa'
@@ -18,20 +18,26 @@ export default function LoginClient() {
   const { t } = useLanguage()
   const supabase = useMemo(() => createSupabaseBrowserClient(), [])
 
+  const syncProfile = useCallback(async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+    if (session?.user) await ensureProfile(supabase, session.user)
+  }, [supabase])
+
   useEffect(() => {
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      const u = session?.user
-      if (u) ensureProfile(supabase, u)
+    } = supabase.auth.onAuthStateChange(() => {
+      syncProfile()
     })
     return () => subscription.unsubscribe()
-  }, [supabase])
+  }, [supabase, syncProfile])
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
-    if (!error && data.user) await ensureProfile(supabase, data.user)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (!error) await syncProfile()
     setMessage(error ? error.message : '')
   }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -154,9 +154,9 @@ export default function Navbar() {
     getUser()
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
       const u = session?.user ?? null
-      if (u) ensureProfile(supabase, u)
+      if (u) await ensureProfile(supabase, u)
       setUser(u)
     })
     return () => {

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -43,7 +43,8 @@ export async function ensureProfile(
   //   ON api.profiles FOR ALL
   //   USING (id = auth.uid()) WITH CHECK (id = auth.uid());
   const { error } = await supabase
-    .from('api.profiles')
+    .schema('api')
+    .from('profiles')
     .upsert(
       {
         id: user.id,
@@ -52,11 +53,12 @@ export async function ensureProfile(
       },
       { onConflict: 'id' }
     )
-    .select('id')
-    .single()
 
   if (error) {
-    console.error('[ensureProfile] Upsert failed:', error)
+    console.error(
+      '[ensureProfile] Upsert failed:',
+      (error as { message?: string })?.message ?? error
+    )
     return
   }
 


### PR DESCRIPTION
## Summary
- sync user profile only after Supabase auth session is ready
- update login, signup, and navbar flows to await session before calling `ensureProfile`
- remove `select` from profile upsert and log clearer errors
- query `profiles` table via `schema('api')` to avoid upsert failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec8e60608326982c863d57f28d22