### PR TITLE
Restrict post creation to authors and admins

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -22,6 +22,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const { data: profile } = await supabase
+    .schema('api')
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (!profile || (profile.role !== 'author' && profile.role !== 'admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const body = await req.json()
   const post = {
     ...body,

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n'
 import { createSupabaseBrowserClient } from '@/lib/supabase'
 import { getCurrentUser } from '@/lib/profile'
@@ -18,11 +17,6 @@ export default function BlogClient() {
   const [posts, setPosts] = useState<Post[]>([])
   const [canCreate, setCanCreate] = useState(false)
   const supabase = useMemo(() => createSupabaseBrowserClient(), [])
-  const router = useRouter()
-  const [title, setTitle] = useState('')
-  const [excerpt, setExcerpt] = useState('')
-  const [body, setBody] = useState('')
-  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -31,8 +25,8 @@ export default function BlogClient() {
         if (res.ok) {
           setPosts(await res.json())
         }
-          const user = await getCurrentUser(supabase)
-          if (user) {
+        const user = await getCurrentUser(supabase)
+        if (user) {
           const { data } = await supabase
             .schema('api')
             .from('profiles')
@@ -50,84 +44,19 @@ export default function BlogClient() {
     load()
   }, [supabase])
 
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    try {
-      const slug = title
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '')
-      const res = await fetch('/posts', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug, title, excerpt, body_md: body }),
-      })
-      if (res.ok) {
-        router.push(`/blog/${slug}`)
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
         <h1 className="font-heading text-3xl font-semibold text-text">{t('blog')}</h1>
         {canCreate && (
-          <section className="mt-8">
-            <h2 className="font-heading text-xl font-semibold text-text">New Post</h2>
-            <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-              <div>
-                <label className="block text-sm text-muted" htmlFor="title">
-                  Title
-                </label>
-                <input
-                  id="title"
-                  type="text"
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-muted" htmlFor="excerpt">
-                  Excerpt
-                </label>
-                <textarea
-                  id="excerpt"
-                  value={excerpt}
-                  onChange={e => setExcerpt(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  rows={2}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-muted" htmlFor="body">
-                  Body (Markdown)
-                </label>
-                <textarea
-                  id="body"
-                  value={body}
-                  onChange={e => setBody(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  rows={6}
-                  required
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={loading}
-                className="rounded-md bg-mint px-4 py-2 font-semibold text-bg hover:bg-mint-strong disabled:opacity-50"
-              >
-                {loading ? 'Publishing...' : 'Publish'}
-              </button>
-            </form>
-          </section>
+          <div className="mt-8">
+            <Link
+              href="/blog/new"
+              className="inline-block rounded-md bg-mint px-4 py-2 font-semibold text-bg hover:bg-mint-strong"
+            >
+              New Post
+            </Link>
+          </div>
         )}
         <div className="mt-8 grid gap-6 sm:grid-cols-2">
           {posts.map(p => (

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState, FormEvent, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -16,6 +16,26 @@ export default function NewPostPage() {
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [preview, setPreview] = useState(false)
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    async function verify() {
+      const user = await getCurrentUser(supabase)
+      if (!user) {
+        router.push('/blog')
+        return
+      }
+      const { data } = await supabase
+        .schema('api')
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single()
+      if (!data || (data.role !== 'author' && data.role !== 'admin')) {
+        router.push('/blog')
+      }
+    }
+    verify()
+  }, [supabase, router])
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- enforce author/admin role check in posts API
- show "New Post" button on blog page for permitted roles
- protect new post page by redirecting clients without author/admin role

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a62173c6608326bd9406f0e568176d