### PR TITLE
Format contact form email output

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -119,6 +119,77 @@ async function graphSendMail(params: {
 // ─────────────────────────────────────────────
 // Handler
 // ─────────────────────────────────────────────
+function escapeHtml(str: string) {
+  return str.replace(/[&<>'"]/g, c => {
+    switch (c) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '"':
+        return '&quot;'
+      case "'":
+        return '&#39;'
+      default:
+        return c
+    }
+  })
+}
+
+function formatContactEmail(
+  name: string,
+  email: string,
+  reason: string,
+  message: string
+): { text: string; html: string } {
+  const fields = [
+    { label: 'Name', value: name },
+    { label: 'Email', value: email },
+    { label: 'Reason', value: reason },
+  ]
+
+  const text = [
+    'Contact Form Submission',
+    ...fields.map(f => `${f.label}: ${f.value || 'N/A'}`),
+    '',
+    'Message:',
+    message,
+  ].join('\n')
+
+  const safeFields = fields.map(f => ({ label: f.label, value: escapeHtml(f.value) || 'N/A' }))
+  const rows = safeFields
+    .map(
+      f =>
+        `<tr><td style="padding:4px 8px;font-weight:bold;">${f.label}:</td><td style="padding:4px 8px;">${f.value}</td></tr>`
+    )
+    .join('')
+
+  const safeMessage = escapeHtml(message).replace(/\n/g, '<br />')
+  const year = new Date().getFullYear()
+
+  const html = [
+    '<!DOCTYPE html>',
+    '<html>',
+    '  <body style="font-family:Arial,sans-serif;line-height:1.5;max-width:600px;margin:auto;">',
+    '    <header style="text-align:center;margin-bottom:20px;">',
+    '      <img src="https://analytixcg.com/images/logos/desktop/logo_navbar.png" alt="Analytix Code Groove" style="height:40px" />',
+    '    </header>',
+    '    <h2 style="margin:0 0 16px 0;">Contact Form Submission</h2>',
+    `    <table style="border-collapse:collapse;width:100%;margin-bottom:16px;">${rows}</table>`,
+    '    <p style="margin:0 0 8px 0;"><strong>Message:</strong></p>',
+    `    <p>${safeMessage}</p>`,
+    '    <footer style="margin-top:32px;font-size:12px;color:#666;text-align:center;border-top:1px solid #eee;padding-top:12px;">',
+    `      © ${year} Analytix Code Groove • <a href="https://analytixcg.com" style="color:#666;text-decoration:none;">analytixcg.com</a>`,
+    '    </footer>',
+    '  </body>',
+    '</html>',
+  ].join('\n')
+
+  return { text, html }
+}
+
 export async function POST(req: Request) {
   try {
     const { name = '', email = '', reason = 'general', message = '' } = await req.json()
@@ -129,21 +200,23 @@ export async function POST(req: Request) {
         ? `Support request from ${name || 'Website'}`
         : `Contact from ${name || 'Website'}`
 
-    const text = `${message}\n\nFrom: ${name}${email ? ` <${email}>` : ''}`
+    const { text, html } = formatContactEmail(name, email, reason, message)
 
     await graphSendMail({
       from: FROM_ADDRESS,
       to,
       subject,
-      text,           // or pass html: '<p>...</p>' if you need formatting
+      text,
+      html,
       replyTo: email || undefined,
     })
 
     return NextResponse.json({ success: true })
-  } catch (err: any) {
+  } catch (err) {
     console.error('Error sending contact email', err)
+    const message = err instanceof Error ? err.message : String(err)
     return NextResponse.json(
-      { success: false, error: String(err?.message ?? err) },
+      { success: false, error: message },
       { status: 500 }
     )
   }


### PR DESCRIPTION
## Summary
- Style contact submissions as a branded mini-report with a logo header, tabular details, and footer
- Include company logo from `images/logos/desktop/logo_navbar.png` in email header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a621165aa48326ab3aef412f9e0767