### PR TITLE
Restrict post creation to authors/admins and support tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,31 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ## Publishing blog posts
 
-Posts can be created from the `/blog/new` page which provides fields for the title, excerpt, Markdown body and an optional image upload. The image is stored in the Supabase `posts` storage bucket under a folder for the current user's UUID and automatically linked to the post.
+Posts can be created from the `/blog/new` page which provides fields for the title, excerpt, tags, Markdown body and an optional image upload. The image is stored in the Supabase `posts` storage bucket under a folder for the current user's UUID and automatically linked to the post.
 
-You can also manage posts through the `/posts` endpoints. To publish a new article programmatically, send a `POST` request with the post data:
+You can also manage posts through the `/api/posts` endpoints. To publish a new article programmatically, send a `POST` request with the post data:
 
 ```bash
-curl -X POST http://localhost:3000/posts \
+curl -X POST http://localhost:3000/api/posts \
   -H 'Content-Type: application/json' \
   -d '{
     "slug": "my-first-post",
     "title": "My First Post",
     "excerpt": "Short summary shown on the blog list",
+    "tags": ["nextjs", "supabase"],
     "body_md": "# Hello world\nThis is my first post!",
     "image_url": "https://your-project.supabase.co/storage/v1/object/public/posts/<user-id>/hello.png"
   }'
 ```
+
+### Markdown formatting
+
+Posts support [Markdown](https://www.markdownguide.org/basic-syntax/) with GitHub Flavored Markdown extensions. Common patterns:
+
+- `# Heading` creates a large title, while `##` and `###` produce progressively smaller subtitles.
+- Use `**bold**` or `*italic*` for emphasis.
+- Start lines with `-` or `1.` to create lists.
+- Embed images anywhere using `![alt text](https://url/to/image.png)`—place the Markdown where you want the image to appear in the article.
 
 ### Uploading images
 
@@ -98,3 +108,4 @@ const {
 ```
 
 Use the `publicUrl` as the `image_url` field when creating the post via the API. The image will appear above the article content on its dedicated page.
+To show images inside the article itself, include their URLs in the Markdown body using the `![alt](url)` syntax at the desired location.

--- a/src/app/api/posts/[slug]/route.ts
+++ b/src/app/api/posts/[slug]/route.ts
@@ -6,6 +6,7 @@ import { createSupabaseServerClient } from '@/lib/supabase'
 export async function GET(_req: Request, context: any) {
   const supabase = createSupabaseServerClient()
   const { data, error } = await supabase
+    .schema('content')
     .from('posts')
     .select('*')
     .eq('slug', context.params.slug)

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -2,6 +2,14 @@ import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase'
 import { getUserFromRequest } from '@/lib/profile'
 
+function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
 // GET /api/posts - public: list all published posts
 export async function GET() {
   const supabase = createSupabaseServerClient()
@@ -22,14 +30,25 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  const { data: profile } = await supabase
+    .schema('api')
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+  if (!profile || (profile.role !== 'author' && profile.role !== 'admin')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const body = await req.json()
+  const { tags = [], ...rest } = body
   const post = {
-    ...body,
+    ...rest,
     author_id: user.id,
     status: body.status ?? 'draft',
   }
 
-  const { data, error } = await supabase
+  const { data: inserted, error } = await supabase
     .schema('content')
     .from('posts')
     .insert(post)
@@ -44,5 +63,36 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 
-  return NextResponse.json(data, { status: 201 })
+  if (tags.length > 0) {
+    const tagRecords = tags.map((name: string) => ({
+      slug: slugify(name),
+      name,
+    }))
+    const tagSlugs = tagRecords.map(t => t.slug)
+    const { error: tagErr } = await supabase
+      .schema('content')
+      .from('tags')
+      .upsert(tagRecords, { onConflict: 'slug' })
+    if (tagErr) {
+      return NextResponse.json({ error: tagErr.message }, { status: 500 })
+    }
+    const { data: rows, error: fetchErr } = await supabase
+      .schema('content')
+      .from('tags')
+      .select('id, slug')
+      .in('slug', tagSlugs)
+    if (fetchErr || !rows) {
+      return NextResponse.json({ error: fetchErr?.message ?? 'Tag fetch failed' }, { status: 500 })
+    }
+    const postTags = rows.map(r => ({ post_slug: inserted.slug, tag_id: r.id }))
+    const { error: linkErr } = await supabase
+      .schema('content')
+      .from('post_tags')
+      .insert(postTags)
+    if (linkErr) {
+      return NextResponse.json({ error: linkErr.message }, { status: 500 })
+    }
+  }
+
+  return NextResponse.json(inserted, { status: 201 })
 }

--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n'
 import { createSupabaseBrowserClient } from '@/lib/supabase'
 import { getCurrentUser } from '@/lib/profile'
@@ -18,21 +17,16 @@ export default function BlogClient() {
   const [posts, setPosts] = useState<Post[]>([])
   const [canCreate, setCanCreate] = useState(false)
   const supabase = useMemo(() => createSupabaseBrowserClient(), [])
-  const router = useRouter()
-  const [title, setTitle] = useState('')
-  const [excerpt, setExcerpt] = useState('')
-  const [body, setBody] = useState('')
-  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/posts')
+        const res = await fetch('/api/posts')
         if (res.ok) {
           setPosts(await res.json())
         }
-          const user = await getCurrentUser(supabase)
-          if (user) {
+        const user = await getCurrentUser(supabase)
+        if (user) {
           const { data } = await supabase
             .schema('api')
             .from('profiles')
@@ -50,84 +44,19 @@ export default function BlogClient() {
     load()
   }, [supabase])
 
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    try {
-      const slug = title
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '')
-      const res = await fetch('/posts', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug, title, excerpt, body_md: body }),
-      })
-      if (res.ok) {
-        router.push(`/blog/${slug}`)
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
         <h1 className="font-heading text-3xl font-semibold text-text">{t('blog')}</h1>
         {canCreate && (
-          <section className="mt-8">
-            <h2 className="font-heading text-xl font-semibold text-text">New Post</h2>
-            <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-              <div>
-                <label className="block text-sm text-muted" htmlFor="title">
-                  Title
-                </label>
-                <input
-                  id="title"
-                  type="text"
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-muted" htmlFor="excerpt">
-                  Excerpt
-                </label>
-                <textarea
-                  id="excerpt"
-                  value={excerpt}
-                  onChange={e => setExcerpt(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  rows={2}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-muted" htmlFor="body">
-                  Body (Markdown)
-                </label>
-                <textarea
-                  id="body"
-                  value={body}
-                  onChange={e => setBody(e.target.value)}
-                  className="mt-1 w-full rounded-md border border-stroke bg-surface px-3 py-2"
-                  rows={6}
-                  required
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={loading}
-                className="rounded-md bg-mint px-4 py-2 font-semibold text-bg hover:bg-mint-strong disabled:opacity-50"
-              >
-                {loading ? 'Publishing...' : 'Publish'}
-              </button>
-            </form>
-          </section>
+          <div className="mt-8">
+            <Link
+              href="/blog/new"
+              className="inline-block rounded-md bg-mint px-4 py-2 font-semibold text-bg hover:bg-mint-strong"
+            >
+              New Post
+            </Link>
+          </div>
         )}
         <div className="mt-8 grid gap-6 sm:grid-cols-2">
           {posts.map(p => (

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,7 +11,7 @@ interface Params {
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
   const { slug } = await params
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const res = await fetch(`${baseUrl}/posts/${slug}`, { cache: 'no-store' })
+  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
   if (!res.ok) {
     return { title: 'Post not found' }
   }
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
 export default async function BlogPostPage({ params }: { params: Promise<Params> }) {
   const { slug } = await params
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const res = await fetch(`${baseUrl}/posts/${slug}`, { cache: 'no-store' })
+  const res = await fetch(`${baseUrl}/api/posts/${slug}`, { cache: 'no-store' })
   if (!res.ok) notFound()
   const post = await res.json()
   return (


### PR DESCRIPTION
## Summary
- enforce author/admin role check in posts API
- show "New Post" button on blog page for permitted roles
- protect new post page by redirecting clients without author/admin role
- document Markdown usage and fix posts API paths
- allow adding comma-separated tags when creating posts, automatically inserting missing tags and linking them to posts
- expand post editor preview to display title, image, markdown body, and tag list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62173c6608326bd9406f0e568176d