### PR TITLE
fix: ensure post cover image stored and referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ curl -X POST http://localhost:3000/api/posts \
     "excerpt": "Short summary shown on the blog list",
     "tags": ["nextjs", "supabase"],
     "body_md": "# Hello world\nThis is my first post!",
-    "image_url": "https://your-project.supabase.co/storage/v1/object/public/posts/<user-id>/hello.png"
+    "cover_url": "https://your-project.supabase.co/storage/v1/object/public/posts/<user-id>/hello.png"
   }'
 ```
 
@@ -107,5 +107,5 @@ const {
 } = supabase.storage.from('posts').getPublicUrl(`${user.id}/hello.png`)
 ```
 
-Use the `publicUrl` as the `image_url` field when creating the post via the API. The image will appear above the article content on its dedicated page.
+Use the `publicUrl` as the `cover_url` field when creating the post via the API. The image will appear above the article content on its dedicated page.
 To show images inside the article itself, include their URLs in the Markdown body using the `![alt](url)` syntax at the desired location.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -29,10 +29,10 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
     <main className="mx-auto max-w-3xl px-4 py-16">
       <h1 className="font-heading text-3xl font-semibold text-text">{post.title}</h1>
       <p className="mt-2 text-muted">{post.excerpt}</p>
-      {post.image_url && (
+      {post.cover_url && (
         <div className="relative mt-6 aspect-[16/9] w-full overflow-hidden rounded-md">
           <Image
-            src={post.image_url}
+            src={post.cover_url}
             alt={post.title}
             fill
             className="object-cover"

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -77,7 +77,7 @@ export default function NewPostPage() {
     e.preventDefault()
     setLoading(true)
     try {
-      let image_url: string | undefined
+      let cover_url: string | undefined
       if (imageFile) {
         const user = await getCurrentUser(supabase)
         if (!user) throw new Error('Not authenticated')
@@ -89,7 +89,7 @@ export default function NewPostPage() {
         const {
           data: { publicUrl },
         } = supabase.storage.from('posts').getPublicUrl(filePath)
-        image_url = publicUrl
+        cover_url = publicUrl
       }
       const slug = title
         .toLowerCase()
@@ -104,7 +104,7 @@ export default function NewPostPage() {
           title,
           excerpt,
           body_md: body,
-          image_url,
+          cover_url,
           tags: tagList,
         }),
       })


### PR DESCRIPTION
## Summary
- send uploaded image URL as `cover_url` when creating posts
- display post cover images using the `cover_url` field
- document use of `cover_url` for API consumers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a63b05b968832699a1d46dca6b6f8e