### PR TITLE
Ensure blog posts publish to Supabase

### DIFF
--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -19,28 +19,29 @@ export default function BlogClient() {
   const supabase = useMemo(() => createSupabaseBrowserClient(), [])
 
   useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch('/api/posts')
-        if (res.ok) {
-          setPosts(await res.json())
-        }
-        const user = await getCurrentUser(supabase)
-        if (user) {
-          const { data } = await supabase
-            .schema('api')
-            .from('profiles')
-            .select('role')
-            .eq('id', user.id)
-            .single()
-          if (data && (data.role === 'author' || data.role === 'admin')) {
-            setCanCreate(true)
+      async function load() {
+        try {
+          const res = await fetch('/api/posts')
+          if (res.ok) {
+            const { items } = await res.json()
+            setPosts(items ?? [])
           }
+          const user = await getCurrentUser(supabase)
+          if (user) {
+            const { data } = await supabase
+              .schema('api')
+              .from('profiles')
+              .select('role')
+              .eq('id', user.id)
+              .single()
+            if (data && (data.role === 'author' || data.role === 'admin')) {
+              setCanCreate(true)
+            }
+          }
+        } catch {
+          // ignore errors for now
         }
-      } catch {
-        // ignore errors for now
       }
-    }
     load()
   }, [supabase])
 

--- a/src/app/blog/new/page.tsx
+++ b/src/app/blog/new/page.tsx
@@ -53,35 +53,18 @@ export default function NewPostPage() {
     setImagePreview(null)
   }, [imageFile])
 
-  useEffect(() => {
-    async function verify() {
-      const user = await getCurrentUser(supabase)
-      if (!user) {
-        router.push('/blog')
-        return
-      }
-      const { data } = await supabase
-        .schema('api')
-        .from('profiles')
-        .select('role')
-        .eq('id', user.id)
-        .single()
-      if (!data || (data.role !== 'author' && data.role !== 'admin')) {
-        router.push('/blog')
-      }
-    }
-    verify()
-  }, [supabase, router])
-
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setLoading(true)
     try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      if (!session) throw new Error('Not authenticated')
+
       let cover_url: string | undefined
       if (imageFile) {
-        const user = await getCurrentUser(supabase)
-        if (!user) throw new Error('Not authenticated')
-        const filePath = `${user.id}/${Date.now()}-${imageFile.name}`
+        const filePath = `${session.user.id}/${Date.now()}-${imageFile.name}`
         const { error: uploadError } = await supabase.storage
           .from('posts')
           .upload(filePath, imageFile, { upsert: true })
@@ -91,14 +74,19 @@ export default function NewPostPage() {
         } = supabase.storage.from('posts').getPublicUrl(filePath)
         cover_url = publicUrl
       }
+
       const slug = title
         .toLowerCase()
         .trim()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '')
+
       const res = await fetch('/api/posts', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
         body: JSON.stringify({
           slug,
           title,
@@ -106,10 +94,14 @@ export default function NewPostPage() {
           body_md: body,
           cover_url,
           tags: tagList,
+          status: 'published',
         }),
       })
+
       if (res.ok) {
         router.push(`/blog/${slug}`)
+      } else {
+        console.error('Failed to publish post', await res.json())
       }
     } finally {
       setLoading(false)

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -72,12 +72,11 @@ export async function ensureProfile(
  * - Calls ensureProfile for the returned user
  */
 export async function getCurrentUser(
-  supabase: SupabaseClient,
-  token?: string
+  supabase: SupabaseClient
 ): Promise<User | null> {
   const {
     data: { user },
-  } = await supabase.auth.getUser(token)
+  } = await supabase.auth.getUser()
   if (user) await ensureProfile(supabase, user)
   return user
 }
@@ -91,7 +90,7 @@ export async function getUserFromRequest(req: Request) {
   const token = authHeader?.startsWith('Bearer ')
     ? authHeader.slice(7)
     : undefined
-  const supabase = createSupabaseServerClient()
-  const user = token ? await getCurrentUser(supabase, token) : null
+  const supabase = createSupabaseServerClient(token)
+  const user = token ? await getCurrentUser(supabase) : null
   return { supabase, user }
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -17,17 +17,25 @@ export function createSupabaseBrowserClient(): SupabaseClient {
 }
 
 /**
- * Create a Supabase client for server-side usage. This uses the service role
- * key which has elevated privileges and should only run on the server.
+ * Create a Supabase client for server-side usage. Accepts an optional access
+ * token so queries run with the caller's RLS context.
  */
-export function createSupabaseServerClient(): SupabaseClient {
+export function createSupabaseServerClient(token?: string): SupabaseClient {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? supabaseConfig.SUPABASE_URL
-  const supabaseServiceKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? supabaseConfig.SUPABASE_SERVICE_ROLE_KEY
+  const supabaseAnonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? supabaseConfig.SUPABASE_ANON_KEY
 
-  if (!supabaseUrl || !supabaseServiceKey) {
+  if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Missing Supabase environment variables')
   }
 
-  return createClient(supabaseUrl, supabaseServiceKey)
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: token
+        ? {
+            Authorization: `Bearer ${token}`,
+          }
+        : {},
+    },
+  })
 }


### PR DESCRIPTION
## Summary
- Send user auth token when creating Supabase server client so RLS policies enforce author permissions
- Rely on RLS in post creation and surface slug conflicts from database
- Correct tag filtering by resolving post slugs before querying posts

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c11feac8326b43f2ce753bfd405