### PR TITLE
List all posts and refine blog cards

### DIFF
--- a/src/app/blog/BlogClient.tsx
+++ b/src/app/blog/BlogClient.tsx
@@ -45,6 +45,8 @@ export default function BlogClient() {
     load()
   }, [supabase])
 
+  const [firstPost, ...otherPosts] = posts
+
   return (
     <main className="min-h-screen">
       <div className="mx-auto max-w-5xl px-4 py-16">
@@ -59,18 +61,33 @@ export default function BlogClient() {
             </Link>
           </div>
         )}
-        <div className="mt-8 grid gap-6 sm:grid-cols-2">
-          {posts.map(p => (
+        <div className="mt-8 space-y-8">
+          {firstPost && (
             <Link
-              key={p.slug}
-              href={`/blog/${p.slug}`}
-              className="rounded-xl2 border border-stroke/70 bg-surface p-6 transition hover:border-mint/60"
+              key={firstPost.slug}
+              href={`/blog/${firstPost.slug}`}
+              className="block rounded-xl2 border border-stroke/70 bg-surface p-8 shadow-soft transition hover:border-mint/60"
             >
-              <h3 className="font-heading text-text">{p.title}</h3>
-              <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
-              <span className="mt-3 block text-sm text-mint">{t('readMore')}</span>
+              <h2 className="text-2xl font-semibold text-text">{firstPost.title}</h2>
+              <p className="mt-2 text-sm text-muted">{firstPost.excerpt}</p>
+              <span className="mt-4 inline-block text-sm text-mint">{t('readMore')}</span>
             </Link>
-          ))}
+          )}
+          {otherPosts.length > 0 && (
+            <div className="space-y-6">
+              {otherPosts.map(p => (
+                <Link
+                  key={p.slug}
+                  href={`/blog/${p.slug}`}
+                  className="block rounded-xl2 border border-stroke/70 bg-surface p-6 transition hover:border-mint/60"
+                >
+                  <h3 className="font-heading text-text">{p.title}</h3>
+                  <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
+                  <span className="mt-3 block text-sm text-mint">{t('readMore')}</span>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </main>

--- a/src/components/LatestPosts.tsx
+++ b/src/components/LatestPosts.tsx
@@ -1,11 +1,37 @@
 "use client"
 
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { posts } from '@/data/posts'
 import { useLanguage } from '@/lib/i18n'
+
+type Post = {
+  slug: string
+  title: string
+  excerpt: string
+}
 
 export default function LatestPosts() {
   const { t } = useLanguage()
+  const [posts, setPosts] = useState<Post[]>([])
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/posts')
+        if (res.ok) {
+          const { items } = await res.json()
+          setPosts(items ?? [])
+        }
+      } catch {
+        // ignore errors for now
+      }
+    }
+    load()
+  }, [])
+
+  const firstTwo = posts.slice(0, 2)
+  const rest = posts.slice(2)
+
   return (
     <section className="bg-bg py-14 mb-24">
       <div className="mx-auto max-w-6xl px-4">
@@ -13,7 +39,7 @@ export default function LatestPosts() {
           {t('latestPosts')}
         </h2>
         <div className="grid gap-6 sm:grid-cols-2">
-          {posts.slice(0, 2).map(p => (
+          {firstTwo.map(p => (
             <Link
               key={p.slug}
               href={`/blog/${p.slug}`}
@@ -25,6 +51,21 @@ export default function LatestPosts() {
             </Link>
           ))}
         </div>
+        {rest.length > 0 && (
+          <div className="mt-6 space-y-6">
+            {rest.map(p => (
+              <Link
+                key={p.slug}
+                href={`/blog/${p.slug}`}
+                className="group rounded-xl2 border border-stroke/70 bg-surface p-6 shadow-soft transition hover:border-mint/60"
+              >
+                <h3 className="text-lg font-semibold text-text group-hover:text-mint">{p.title}</h3>
+                <p className="mt-2 text-sm text-muted">{p.excerpt}</p>
+                <span className="mt-4 inline-block text-sm text-mint">{t('readMore')}</span>
+              </Link>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- add GET `/api/posts` endpoint returning published posts sorted by date
- fetch posts for LatestPosts component and stack additional entries after first two
- highlight newest post on blog page with a large card and list remaining posts below

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a65d15945c83269ab350c773f1754a