### PR TITLE
Fix blog post content not rendering

### DIFF
--- a/src/app/api/posts/[slug]/route.ts
+++ b/src/app/api/posts/[slug]/route.ts
@@ -37,17 +37,18 @@ export async function GET(req: Request, ctx: Ctx) {
       title: string
       excerpt: string | null
       body_md: string | null
-    }
+    }[]
   }
   const row = data as Row
+  const tr = row.post_translations[0]
   return NextResponse.json({
     slug: row.slug,
     cover_url: row.cover_url,
     published_at: row.published_at,
     author_id: row.author_id,
     status: row.status,
-    title: row.post_translations.title,
-    excerpt: row.post_translations.excerpt,
-    body_md: row.post_translations.body_md,
+    title: tr?.title,
+    excerpt: tr?.excerpt,
+    body_md: tr?.body_md,
   })
 }


### PR DESCRIPTION
## Summary
- ensure post translation data is handled as an array
- return translation fields (title, excerpt, body) from first entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7373ecc6c83268dcf7ba3ebf43661