### PR TITLE
Honor navbar language on blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import ShareButtons from '@/components/ShareButtons'
-import { headers } from 'next/headers'
+import { headers, cookies } from 'next/headers'
 import fs from 'node:fs'
 import path from 'node:path'
 import { createSupabaseServerClient } from '@/lib/supabase'
@@ -59,9 +59,16 @@ export async function generateMetadata(
   { params }: { params: Promise<Params> }
 ): Promise<Metadata> {
   const { slug } = await params
+  const cookieStore = cookies()
+  const cookieLang = cookieStore.get('lang')?.value
   const headersList = await headers()
   const langHeader = headersList.get('accept-language')?.toLowerCase() ?? ''
-  let lang: 'en' | 'es' = langHeader.startsWith('es') ? 'es' : 'en'
+  let lang: 'en' | 'es' =
+    cookieLang === 'es' || cookieLang === 'en'
+      ? cookieLang
+      : langHeader.startsWith('es')
+        ? 'es'
+        : 'en'
   let post = await fetchPost(slug, lang)
   if (!post && lang === 'es') {
     lang = 'en'
@@ -90,9 +97,16 @@ export default async function BlogPostPage(
   { params }: { params: Promise<Params> }
 ) {
   const { slug } = await params
+  const cookieStore = cookies()
+  const cookieLang = cookieStore.get('lang')?.value
   const headersList = await headers()
   const langHeader = headersList.get('accept-language')?.toLowerCase() ?? ''
-  let lang: 'en' | 'es' = langHeader.startsWith('es') ? 'es' : 'en'
+  let lang: 'en' | 'es' =
+    cookieLang === 'es' || cookieLang === 'en'
+      ? cookieLang
+      : langHeader.startsWith('es')
+        ? 'es'
+        : 'en'
   let post = await fetchPost(slug, lang)
   if (!post && lang === 'es') {
     lang = 'en'

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -345,19 +345,28 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
     const stored = localStorage.getItem('lang') as Language | null
     if (stored) {
       setLangState(stored)
-    } else {
-      const browser = navigator.language.slice(0, 2)
-      if (browser === 'es') setLangState('es')
+      return
     }
+    const cookieMatch = document.cookie.match(/(^| )lang=([^;]+)/)
+    if (cookieMatch) {
+      const value = cookieMatch[2] as Language
+      if (value === 'es' || value === 'en') {
+        setLangState(value)
+        return
+      }
+    }
+    const browser = navigator.language.slice(0, 2)
+    if (browser === 'es') setLangState('es')
   }, [])
 
   useEffect(() => {
     document.documentElement.lang = lang
+    localStorage.setItem('lang', lang)
+    document.cookie = `lang=${lang}; path=/`
   }, [lang])
 
   const setLang = (l: Language) => {
     setLangState(l)
-    localStorage.setItem('lang', l)
   }
 
   const t = (key: string) => translations[lang][key] ?? key


### PR DESCRIPTION
## Summary
- ensure language selection stores cookie so server renders in chosen language
- pull blog post language from cookie with Accept-Language fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a743064eb88326af017795a3326e25