### PR TITLE
Refresh slug page on language switch

### DIFF
--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 type Language = 'en' | 'es'
 
@@ -340,6 +341,7 @@ const LanguageContext = createContext<LanguageContextProps | undefined>(
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [lang, setLangState] = useState<Language>('en')
+  const router = useRouter()
 
   useEffect(() => {
     const stored = localStorage.getItem('lang') as Language | null
@@ -367,6 +369,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const setLang = (l: Language) => {
     setLangState(l)
+    router.refresh()
   }
 
   const t = (key: string) => translations[lang][key] ?? key


### PR DESCRIPTION
## Summary
- refresh router when language is changed to update server-rendered content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Can't resolve '../../supabase.local.json')


------
https://chatgpt.com/codex/tasks/task_e_68a7453aa4e4832682560ba040456f39