### PR TITLE
docs: add setup guides and role assignment API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+ADMIN_SECRET=change-me
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-password
+SMTP_FROM="Analytix Code Groove <info@example.com>"
+EMAIL_TO_SUPPORT=support@example.com
+EMAIL_TO_INFO=info@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
+.env.development
+.env.test
+.env.production
 
 # vercel
 .vercel
@@ -42,4 +46,3 @@ next-env.d.ts
 
 # auth
 supabase.local.json
-.env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+1. Fork the repository and clone your fork.
+2. Run `npm install` to install dependencies.
+3. Copy `supabase.local.example.json` to `supabase.local.json` and `.env.example` to `.env.local`, then add your own credentials.
+4. Start the development server with `npm run dev` and make your changes.
+5. Create a new branch for your work and commit with clear messages.
+6. Run `npm run lint` before submitting your changes.
+7. Push the branch and open a pull request.
+
+Thanks for contributing!
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+Clone the repository and install dependencies:
+
+```bash
+git clone <your-fork-url>
+cd web-app
+npm install
+```
+
+Copy the example configuration files and fill in your own credentials:
+
+```bash
+cp supabase.local.example.json supabase.local.json
+cp .env.example .env.local
+```
+
+Then run the development server:
 
 ```bash
 npm run dev
@@ -22,7 +37,7 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 ## Auth Configuration
 
-Create a `supabase.local.json` file in the project root with your Supabase project credentials, OAuth provider keys, and SMTP settings used by the contact form:
+Create a `supabase.local.json` file in the project root (start from `supabase.local.example.json`) with your Supabase project credentials, OAuth provider keys, and SMTP settings used by the contact form:
 
 ```
 {
@@ -40,13 +55,33 @@ Create a `supabase.local.json` file in the project root with your Supabase proje
   "SMTP_SECURE": false,
   "SMTP_USER": "your-smtp-username",
   "SMTP_PASS": "your-smtp-password",
-  "SMTP_FROM": "Analytix Code Groove <info@example.com>",
-  "EMAIL_TO_SUPPORT": "support@example.com",
-  "EMAIL_TO_INFO": "info@example.com"
+"SMTP_FROM": "Analytix Code Groove <info@example.com>",
+"EMAIL_TO_SUPPORT": "support@example.com",
+"EMAIL_TO_INFO": "info@example.com",
+"SUPABASE_SERVICE_ROLE_KEY": "your-service-role-key",
+"ADMIN_SECRET": "change-me"
 }
 ```
 
 The file is ignored by Git and any values it defines are used only when corresponding environment variables are absent.
+
+You can alternatively set these values in `.env.local`; see `.env.example` for the expected keys.
+
+## Assigning roles
+
+To publish blog posts, your user must have the `admin` or `author` role. The repository exposes a protected endpoint that lets you promote a user when developing locally.
+
+1. Set a secret token in your environment (`ADMIN_SECRET` in `.env.local` or `supabase.local.json`).
+2. Use the `/api/roles` endpoint with that secret to update a user's role:
+
+```bash
+curl -X POST http://localhost:3000/api/roles \
+  -H "Authorization: Bearer $ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "<user-uuid>", "role": "author"}'
+```
+
+Valid roles are `admin`, `author` and `client` (the default). Only requests presenting the correct `ADMIN_SECRET` will succeed.
 
 ## Learn More
 

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,0 +1,43 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+import { NextResponse } from 'next/server'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createSupabaseAdminClient } from '@/lib/supabaseAdmin'
+
+function loadAdminSecret(): string | undefined {
+  if (process.env.ADMIN_SECRET) return process.env.ADMIN_SECRET
+  try {
+    const file = fs.readFileSync(path.join(process.cwd(), 'supabase.local.json'), 'utf8')
+    const json = JSON.parse(file) as Record<string, string>
+    return json['ADMIN_SECRET']
+  } catch {
+    return undefined
+  }
+}
+
+export async function POST(req: Request) {
+  const secret = loadAdminSecret()
+  if (!secret) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
+  }
+  const auth = req.headers.get('authorization')
+  if (!auth || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { user_id, role } = await req.json()
+  if (typeof user_id !== 'string' || !['admin', 'author', 'client'].includes(role)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+  const supabase = createSupabaseAdminClient()
+  const { error } = await supabase
+    .schema('api')
+    .from('profiles')
+    .update({ role })
+    .eq('id', user_id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}

--- a/supabase.local.example.json
+++ b/supabase.local.example.json
@@ -1,0 +1,21 @@
+{
+  "SUPABASE_URL": "https://your-project.supabase.co",
+  "SUPABASE_ANON_KEY": "your-supabase-anon-key",
+  "SUPABASE_SERVICE_ROLE_KEY": "your-service-role-key",
+  "GITHUB_APP_NAME": "AnalytixCG (Dev)",
+  "GITHUB_CLIENT_ID": "your-client-id",
+  "GITHUB_CLIENT_SECRET": "your-client-secret",
+  "GOOGLE_APP_NAME": "AnalytixCG (Dev)",
+  "GOOGLE_CLIENT_ID": "your-client-id",
+  "GOOGLE_CLIENT_SECRET": "your-client-secret",
+  "SUPABASE_CALLBACK_URL": "https://your-project.supabase.co/auth/v1/callback",
+  "SMTP_HOST": "smtp.example.com",
+  "SMTP_PORT": 587,
+  "SMTP_SECURE": false,
+  "SMTP_USER": "your-smtp-username",
+  "SMTP_PASS": "your-smtp-password",
+  "SMTP_FROM": "Analytix Code Groove <info@example.com>",
+  "EMAIL_TO_SUPPORT": "support@example.com",
+  "EMAIL_TO_INFO": "info@example.com",
+  "ADMIN_SECRET": "change-me"
+}


### PR DESCRIPTION
## Summary
- document local setup with example env files
- add protected `/api/roles` endpoint for promoting users
- provide contributing guidelines

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04902c3c48326bd8af2284ea8303f