### PR TITLE
Add Clutch widget to footer and align it left

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,10 @@ export default function RootLayout({
           src="https://www.googletagmanager.com/gtag/js?id=G-LP2YGD26S7"
           strategy="beforeInteractive"
         />
+        <Script
+          src="https://widget.clutch.co/static/js/widget.js"
+          strategy="lazyOnload"
+        />
         <Script id="google-tag" strategy="beforeInteractive">
           {`window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import Script from 'next/script'
 import { useLanguage } from '@/lib/i18n'
 import { FaLinkedin } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -96,8 +95,7 @@ export default function Footer() {
         {/* Bottom bar */}
         <div className="mt-4 flex flex-col items-center gap-3 text-center text-xs text-muted sm:flex-row sm:justify-between sm:text-left">
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center">
-            <div className="clutch-container flex h-8 items-center">
-              <Script src="https://widget.clutch.co/static/js/widget.js" strategy="afterInteractive" />
+            <div className="clutch-container flex h-8 min-w-[88px] items-center">
               <div
                 className="clutch-widget"
                 data-url="https://widget.clutch.co"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
+import Script from 'next/script'
 import { useLanguage } from '@/lib/i18n'
 import { FaLinkedin } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -94,7 +95,22 @@ export default function Footer() {
 
         {/* Bottom bar */}
         <div className="mt-4 flex flex-col items-center gap-3 text-center text-xs text-muted sm:flex-row sm:justify-between sm:text-left">
-          <p>© Analytixcg</p>
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center">
+            <div className="clutch-container flex h-8 items-center">
+              <Script src="https://widget.clutch.co/static/js/widget.js" strategy="afterInteractive" />
+              <div
+                className="clutch-widget"
+                data-url="https://widget.clutch.co"
+                data-widget-type="2"
+                data-height="32"
+                data-nofollow="false"
+                data-expandifr="true"
+                data-darkbg="darkbg"
+                data-clutchcompany-id="2607562"
+              />
+            </div>
+            <p>© Analytixcg</p>
+          </div>
           <div className="flex items-center gap-2">
             <a
               href="https://x.com/Analytixcg"


### PR DESCRIPTION
### Motivation
- Place the Clutch social icon in the footer bottom bar at the left for better visibility and to satisfy the layout request.

### Description
- Import `Script` from `next/script` and add the Clutch widget markup to `src/components/Footer.tsx` bottom bar. 
- Load the Clutch script with `strategy="afterInteractive"` and include a `div.clutch-widget` with the required `data-*` attributes (including `data-clutchcompany-id="2607562"`).
- Wrap the widget and copyright text in a left-aligned flex container so the widget appears before the `© Analytixcg` text.

### Testing
- Ran `npm run dev` and the Next.js dev server started and reported ready. 
- Executed a Playwright script to navigate to `http://127.0.0.1:3000` and capture a screenshot saved as `artifacts/footer-clutch.png`.
- The root page returned `500` due to a runtime error (`Missing Supabase config` from `src/lib/supabase.ts`), so full end-to-end rendering did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69834371b51c8326afa9221994f7137f)